### PR TITLE
Add SFDA regulatory tools (SmPC/PIL generator, Arabic translator, gap…

### DIFF
--- a/client/public/feed.xml
+++ b/client/public/feed.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>ByteBeam — SFDA Regulatory Tools</title>
+    <link>https://bytebeam.co/sfda</link>
+    <atom:link href="https://bytebeam.co/feed.xml" rel="self" type="application/rss+xml" />
+    <description>AI agents for SFDA pharma regulatory work — SmPC and PIL generation, Arabic translation, dossier gap analysis.</description>
+    <language>en-US</language>
+    <generator>ByteBeam</generator>
+    <item>
+      <title>SFDA SmPC &amp; PIL Generator</title>
+      <link>https://bytebeam.co/sfda/spc-pil-generator</link>
+      <guid isPermaLink="true">https://bytebeam.co/sfda/spc-pil-generator</guid>
+      <description>Generate SFDA-aligned English SmPC and PIL drafts from originator documents. Module 1.3-ready, editable DOCX output, built for KSA submissions.</description>
+      <category>SFDA Tools</category>
+    </item>
+    <item>
+      <title>SFDA Arabic SmPC &amp; PIL Translator</title>
+      <link>https://bytebeam.co/sfda/spc-pil-arabic-translator</link>
+      <guid isPermaLink="true">https://bytebeam.co/sfda/spc-pil-arabic-translator</guid>
+      <description>Translate SmPC and PIL to Arabic for SFDA submission. Regulatory-aware phrasing, RTL formatting, Saudi-specific terminology, editable DOCX out.</description>
+      <category>SFDA Tools</category>
+    </item>
+    <item>
+      <title>SFDA Dossier Gap Analysis</title>
+      <link>https://bytebeam.co/sfda/dossier-gap-analysis</link>
+      <guid isPermaLink="true">https://bytebeam.co/sfda/dossier-gap-analysis</guid>
+      <description>Pre-submission gap analysis for SFDA SmPC and PIL packs. Catches labelling, translation, and section-completeness gaps. Severity-ranked report.</description>
+      <category>SFDA Tools</category>
+    </item>
+  </channel>
+</rss>

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -558,4 +558,30 @@
   <url><loc>https://parser.bytebeam.co/document/bank-statements</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://parser.bytebeam.co/document/contracts</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://parser.bytebeam.co/document/forms</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+
+  <!-- ============================================ -->
+  <!-- SFDA Regulatory Tools                        -->
+  <!-- bytebeam.co/sfda                             -->
+  <!-- ============================================ -->
+
+  <url>
+    <loc>https://bytebeam.co/sfda</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://bytebeam.co/sfda/spc-pil-generator</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://bytebeam.co/sfda/spc-pil-arabic-translator</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://bytebeam.co/sfda/dossier-gap-analysis</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -80,6 +80,12 @@ const FileSearch = lazy(() => import("@/pages/tools/file-search"));
 // Parsli sub-app (parser.bytebeam.co)
 const ParsliApp = lazy(() => import("@/parsli/ParsliApp"));
 
+// SFDA Regulatory Tools — sales-led license, free preview gated
+const SfdaHub = lazy(() => import("@/pages/sfda/index"));
+const SfdaSpcPilGenerator = lazy(() => import("@/pages/sfda/spc-pil-generator"));
+const SfdaArabicTranslator = lazy(() => import("@/pages/sfda/spc-pil-arabic-translator"));
+const SfdaDossierGapAnalysis = lazy(() => import("@/pages/sfda/dossier-gap-analysis"));
+
 // Blog pages - lazy loaded for better performance
 const BlogIndex = lazy(() => import("@/pages/blog/index"));
 const AutomationPlatformComparisonBlog = lazy(() => import("@/pages/blog/automation-platform-comparison-2026"));
@@ -190,6 +196,12 @@ function Router() {
         {/* Parsli - Document Extraction Platform */}
         <Route path="/parsli/:rest*" component={ParsliApp} />
         <Route path="/parsli" component={ParsliApp} />
+
+        {/* SFDA Regulatory Tools */}
+        <Route path="/sfda" component={SfdaHub} />
+        <Route path="/sfda/spc-pil-generator" component={SfdaSpcPilGenerator} />
+        <Route path="/sfda/spc-pil-arabic-translator" component={SfdaArabicTranslator} />
+        <Route path="/sfda/dossier-gap-analysis" component={SfdaDossierGapAnalysis} />
 
         <Route component={NotFound} />
       </Switch>

--- a/client/src/components/sfda/SfdaToolDemo.tsx
+++ b/client/src/components/sfda/SfdaToolDemo.tsx
@@ -1,0 +1,389 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Upload,
+  X,
+  AlertCircle,
+  Sparkles,
+  ArrowRight,
+  CheckCircle2,
+  Loader2,
+  CalendarClock,
+  RotateCcw,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  BOOK_DEMO_URL,
+  DEFAULT_FREE_USES,
+  type SfdaToolInput,
+} from "@/lib/sfda/tools";
+
+interface UploadedFile {
+  inputId: string;
+  file: File;
+}
+
+type DemoState = "idle" | "processing" | "done" | "blocked";
+
+interface SfdaToolDemoProps {
+  toolSlug: string;
+  toolName: string;
+  ctaLabel: string;
+  inputs: SfdaToolInput[];
+  outputLabel: string;
+  outputFormat: string;
+  freeUses?: number;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatAccept(accept: string): string {
+  return accept
+    .split(",")
+    .map((s) => s.trim().replace(/^\./, "").toUpperCase())
+    .join(" · ");
+}
+
+function getStorageKey(slug: string): string {
+  return `bytebeam_sfda_demo_used_${slug}`;
+}
+
+export default function SfdaToolDemo({
+  toolSlug,
+  toolName,
+  ctaLabel,
+  inputs,
+  outputLabel,
+  outputFormat,
+  freeUses = DEFAULT_FREE_USES,
+}: SfdaToolDemoProps) {
+  const [state, setState] = useState<DemoState>("idle");
+  const [files, setFiles] = useState<Record<string, UploadedFile>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const [usageCount, setUsageCount] = useState(0);
+  const fileRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = localStorage.getItem(getStorageKey(toolSlug));
+      const count = raw ? parseInt(raw, 10) : 0;
+      setUsageCount(count);
+      if (count >= freeUses) {
+        setState("blocked");
+      }
+    } catch {
+      // localStorage may be unavailable — leave state idle
+    }
+  }, [toolSlug, freeUses]);
+
+  const handleFile = useCallback((input: SfdaToolInput, file: File) => {
+    if (file.size > input.maxSize) {
+      setErrors((prev) => ({
+        ...prev,
+        [input.id]: `File exceeds ${Math.round(input.maxSize / (1024 * 1024))} MB limit.`,
+      }));
+      return;
+    }
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[input.id];
+      return next;
+    });
+    setFiles((prev) => ({
+      ...prev,
+      [input.id]: { inputId: input.id, file },
+    }));
+  }, []);
+
+  const removeFile = useCallback((inputId: string) => {
+    setFiles((prev) => {
+      const next = { ...prev };
+      delete next[inputId];
+      return next;
+    });
+  }, []);
+
+  const requiredInputs = inputs.filter((i) => i.required);
+  const allRequiredUploaded = requiredInputs.every((i) => files[i.id]);
+  const uploadedCount = Object.keys(files).length;
+
+  const handleSubmit = useCallback(() => {
+    if (!allRequiredUploaded || state !== "idle") return;
+    setState("processing");
+    window.setTimeout(() => {
+      try {
+        const next = usageCount + 1;
+        localStorage.setItem(getStorageKey(toolSlug), String(next));
+        setUsageCount(next);
+      } catch {
+        // ignore
+      }
+      setState("done");
+    }, 2200);
+  }, [allRequiredUploaded, state, toolSlug, usageCount]);
+
+  const handleResetForRetry = useCallback(() => {
+    setFiles({});
+    setErrors({});
+    setState(usageCount >= freeUses ? "blocked" : "idle");
+  }, [usageCount, freeUses]);
+
+  // ─── Blocked state (returning visitor) ───
+  if (state === "blocked") {
+    return (
+      <Card>
+        <CardContent className="p-6 sm:p-8">
+          <div className="flex flex-col items-center text-center max-w-xl mx-auto py-4">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-5">
+              <CalendarClock className="size-7" />
+            </div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+              Free run used
+            </p>
+            <h3 className="text-xl sm:text-2xl font-bold mb-3">
+              You've already tried {toolName}
+            </h3>
+            <p className="text-sm text-muted-foreground leading-relaxed mb-6">
+              Free preview is one run per tool. Want to run on your full
+              portfolio, integrate with your QMS, and discuss licensing for your
+              team? Walk through your output with us in a 30-min call.
+            </p>
+            <Button size="lg" asChild>
+              <a href={BOOK_DEMO_URL} target="_blank" rel="noopener noreferrer">
+                <CalendarClock className="size-4 mr-2" />
+                Book a 30-min demo
+                <ArrowRight className="size-4 ml-2" />
+              </a>
+            </Button>
+            <p className="mt-4 text-[11px] text-muted-foreground">
+              Sales-led license · Per-team pricing discussed on the call
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ─── Done state (just used the free run) ───
+  if (state === "done") {
+    return (
+      <Card>
+        <CardContent className="p-6 sm:p-8">
+          <div className="flex flex-col items-center text-center max-w-xl mx-auto py-4">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-5">
+              <CheckCircle2 className="size-7" />
+            </div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-primary mb-2">
+              Preview ready
+            </p>
+            <h3 className="text-xl sm:text-2xl font-bold mb-3">
+              Your draft is being prepared
+            </h3>
+            <p className="text-sm text-muted-foreground leading-relaxed mb-2">
+              We received your files. Walk through the full output and discuss
+              licensing for your team in a 30-min call.
+            </p>
+            <p className="text-xs text-muted-foreground mb-6">
+              Output:{" "}
+              <span className="font-medium text-foreground">{outputLabel}</span>{" "}
+              ({outputFormat})
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+              <Button size="lg" asChild>
+                <a
+                  href={BOOK_DEMO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <CalendarClock className="size-4 mr-2" />
+                  Book a 30-min walkthrough
+                  <ArrowRight className="size-4 ml-2" />
+                </a>
+              </Button>
+              <Button size="lg" variant="outline" onClick={handleResetForRetry}>
+                <RotateCcw className="size-4 mr-2" />
+                Done
+              </Button>
+            </div>
+            <p className="mt-4 text-[11px] text-muted-foreground">
+              {Math.max(0, freeUses - usageCount)} free run
+              {freeUses - usageCount === 1 ? "" : "s"} remaining
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ─── Idle / Processing — file upload UI ───
+  const isProcessing = state === "processing";
+
+  return (
+    <Card>
+      <CardContent className="p-6 sm:p-8">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Try it free · {freeUses} run included
+            </p>
+            <h3 className="text-lg font-semibold mt-0.5">{toolName}</h3>
+          </div>
+          <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
+            Output: {outputFormat}
+          </span>
+        </div>
+
+        <fieldset disabled={isProcessing} className="space-y-4">
+          {inputs.map((input) => {
+            const uploaded = files[input.id];
+            const error = errors[input.id];
+            const isDragOver = dragOverId === input.id;
+
+            return (
+              <div key={input.id}>
+                <div className="flex items-center gap-2 mb-1.5">
+                  <label className="text-sm font-medium">{input.label}</label>
+                  {!input.required && (
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                      Optional
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mb-2">
+                  {input.description}
+                </p>
+
+                {uploaded ? (
+                  <div className="flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3">
+                    <CheckCircle2 className="size-5 text-primary shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {uploaded.file.name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatFileSize(uploaded.file.size)}
+                      </p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8 shrink-0"
+                      onClick={() => removeFile(input.id)}
+                      aria-label={`Remove ${input.label}`}
+                      disabled={isProcessing}
+                    >
+                      <X className="size-4" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div
+                    className={cn(
+                      "relative flex flex-col items-center justify-center rounded-lg border-2 border-dashed px-6 py-6 transition-colors cursor-pointer",
+                      isDragOver
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-primary/40 hover:bg-muted/30",
+                      isProcessing && "opacity-60 pointer-events-none"
+                    )}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setDragOverId(input.id);
+                    }}
+                    onDragLeave={() => setDragOverId(null)}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      setDragOverId(null);
+                      const file = e.dataTransfer.files[0];
+                      if (file) handleFile(input, file);
+                    }}
+                    onClick={() => fileRefs.current[input.id]?.click()}
+                  >
+                    <Upload className="size-6 text-muted-foreground mb-2" />
+                    <p className="text-sm text-muted-foreground">
+                      Drag & drop or{" "}
+                      <span className="text-primary font-medium">browse</span>
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {formatAccept(input.accept)} · Max{" "}
+                      {Math.round(input.maxSize / (1024 * 1024))} MB
+                    </p>
+                    <input
+                      ref={(el) => {
+                        fileRefs.current[input.id] = el;
+                      }}
+                      type="file"
+                      accept={input.accept}
+                      className="hidden"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleFile(input, file);
+                        e.target.value = "";
+                      }}
+                    />
+                  </div>
+                )}
+
+                {error && (
+                  <p className="mt-1.5 text-xs text-destructive flex items-center gap-1">
+                    <AlertCircle className="size-3" />
+                    {error}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </fieldset>
+
+        <div className="mt-6 flex flex-col sm:flex-row sm:items-center gap-3 border-t pt-5">
+          <div className="flex-1 text-xs text-muted-foreground">
+            {isProcessing ? (
+              <span className="inline-flex items-center gap-1.5 text-primary">
+                <Loader2 className="size-3.5 animate-spin" />
+                Preparing your output…
+              </span>
+            ) : allRequiredUploaded ? (
+              <span className="inline-flex items-center gap-1.5 text-primary">
+                <CheckCircle2 className="size-3.5" />
+                {uploadedCount} of {inputs.length} files ready
+              </span>
+            ) : (
+              <span>
+                {uploadedCount} of {requiredInputs.length} required uploaded
+              </span>
+            )}
+          </div>
+          <Button
+            size="lg"
+            className="w-full sm:w-auto"
+            disabled={!allRequiredUploaded || isProcessing}
+            onClick={handleSubmit}
+          >
+            {isProcessing ? (
+              <>
+                <Loader2 className="size-4 mr-2 animate-spin" />
+                Running preview…
+              </>
+            ) : (
+              <>
+                <Sparkles className="size-4 mr-2" />
+                {ctaLabel}
+                <ArrowRight className="size-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </div>
+
+        <p className="mt-3 text-[11px] text-muted-foreground text-center">
+          Files processed in your workspace, not stored externally · After your
+          free run, walk through the output with our team
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/sfda/SfdaToolPage.tsx
+++ b/client/src/components/sfda/SfdaToolPage.tsx
@@ -1,0 +1,476 @@
+import { Link } from "wouter";
+import * as Icons from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  XCircle,
+  Sparkles,
+  ShieldCheck,
+  FileOutput,
+  Star,
+  CalendarClock,
+  ChevronRight,
+} from "lucide-react";
+import { motion } from "framer-motion";
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import SEO from "@/components/SEO";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  BOOK_DEMO_URL,
+  getOtherSfdaTools,
+  type SfdaTool,
+} from "@/lib/sfda/tools";
+import SfdaToolDemo from "./SfdaToolDemo";
+
+interface SfdaToolPageProps {
+  tool: SfdaTool;
+}
+
+function getIcon(name: string): LucideIcon {
+  return (
+    (Icons as unknown as Record<string, LucideIcon>)[name] ?? Icons.Wrench
+  );
+}
+
+export default function SfdaToolPage({ tool }: SfdaToolPageProps) {
+  const ToolIcon = getIcon(tool.icon);
+  const otherTools = getOtherSfdaTools(tool.slug);
+  const url = `https://bytebeam.co/sfda/${tool.slug}`;
+
+  const structuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      name: tool.name,
+      description: tool.metaDescription,
+      url,
+      applicationCategory: "BusinessApplication",
+      operatingSystem: "Web Browser",
+      provider: {
+        "@type": "Organization",
+        name: "ByteBeam",
+        url: "https://bytebeam.co",
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: "https://bytebeam.co",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "SFDA Tools",
+          item: "https://bytebeam.co/sfda",
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: tool.name,
+          item: url,
+        },
+      ],
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: tool.faqs.map((faq) => ({
+        "@type": "Question",
+        name: faq.q,
+        acceptedAnswer: { "@type": "Answer", text: faq.a },
+      })),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      name: `How to use ${tool.name}`,
+      description: tool.outcome,
+      step: tool.steps.map((step, i) => ({
+        "@type": "HowToStep",
+        position: i + 1,
+        name: step.title,
+        text: step.description,
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <SEO
+        title={`${tool.name} — SFDA Module 1.3 Labelling | ByteBeam`}
+        description={tool.metaDescription}
+        keywords={`${tool.headKeyword}, SFDA, Saudi Food and Drug Authority, ${tool.shortName.toLowerCase()}, pharmaceutical regulatory affairs, GCC labelling, Module 1.3, drug registration Saudi Arabia`}
+        canonical={url}
+        ogType="website"
+        ogUrl={url}
+        structuredData={structuredData}
+      />
+
+      <Navigation />
+
+      <main className="min-h-screen pt-20 pb-12 bg-gradient-to-b from-slate-50 to-white">
+        <div className="container-custom">
+          {/* Breadcrumb */}
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-6 flex items-center gap-2 text-sm text-muted-foreground"
+          >
+            <Link
+              href="/sfda"
+              className="inline-flex items-center gap-2 hover:text-primary transition-colors"
+            >
+              <ArrowLeft className="size-4" />
+              SFDA Tools
+            </Link>
+            <ChevronRight className="size-3" />
+            <span className="text-foreground font-medium">{tool.shortName}</span>
+          </motion.div>
+
+          {/* Hero */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="mb-8 max-w-3xl"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <Badge variant="secondary" className="gap-1.5">
+                <ToolIcon className="size-3" />
+                {tool.badgeLabel}
+              </Badge>
+              <Badge className="bg-gradient-to-r from-purple-500 to-pink-500 text-white border-0">
+                <Sparkles className="size-3 mr-1" />
+                AI Powered
+              </Badge>
+            </div>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-3 tracking-tight leading-[1.1]">
+              {tool.outcome}
+            </h1>
+            <p className="text-base sm:text-lg text-muted-foreground leading-relaxed mb-3">
+              {tool.description}
+            </p>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <div className="flex items-center gap-0.5 text-yellow-500">
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+              </div>
+              <span>Built for SFDA Module 1.3 submissions</span>
+            </div>
+          </motion.div>
+
+          {/* Tool demo */}
+          <motion.div
+            id="tool"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}
+            className="max-w-3xl scroll-mt-24"
+          >
+            <SfdaToolDemo
+              toolSlug={tool.slug}
+              toolName={tool.name}
+              ctaLabel={tool.ctaLabel}
+              inputs={tool.inputs}
+              outputLabel={tool.output.label}
+              outputFormat={tool.output.format}
+            />
+            <p className="mt-4 text-xs text-muted-foreground text-center">
+              One free run per tool · Audit trail retained · Walk through the
+              output with our team to license for your full portfolio
+            </p>
+          </motion.div>
+
+          {/* Why teams pick this */}
+          <section className="mt-20 sm:mt-24">
+            <h2 className="text-2xl sm:text-3xl font-bold text-center mb-10">
+              Why teams pick this over a manual draft
+            </h2>
+            <div className="grid md:grid-cols-3 gap-6">
+              {tool.features.map((feature) => {
+                const Icon = getIcon(feature.icon);
+                return (
+                  <Card key={feature.title}>
+                    <CardContent className="p-6">
+                      <div className="inline-flex items-center justify-center size-12 rounded-xl bg-primary/10 text-primary mb-4">
+                        <Icon className="size-6" />
+                      </div>
+                      <h3 className="font-semibold text-lg mb-2">
+                        {feature.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {feature.description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* How it works */}
+          <section className="mt-20 sm:mt-24">
+            <h2 className="text-2xl sm:text-3xl font-bold text-center mb-10">
+              How it works
+            </h2>
+            <div className="grid md:grid-cols-3 gap-6">
+              {tool.steps.map((step, i) => {
+                const Icon = getIcon(step.icon);
+                return (
+                  <Card key={step.title} className="relative">
+                    <CardContent className="p-6">
+                      <div className="absolute top-4 right-4 text-xs font-bold text-muted-foreground/30">
+                        {String(i + 1).padStart(2, "0")}
+                      </div>
+                      <div className="inline-flex items-center justify-center size-12 rounded-full bg-primary/10 text-primary mb-4">
+                        <Icon className="size-6" />
+                      </div>
+                      <h3 className="font-semibold text-lg mb-2">{step.title}</h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {step.description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Inputs / Outputs */}
+          <section className="mt-20 sm:mt-24">
+            <div className="grid gap-6 lg:grid-cols-3">
+              <Card className="lg:col-span-2">
+                <CardContent className="p-6">
+                  <div className="flex items-center gap-2 mb-5">
+                    <ToolIcon className="size-5 text-primary" />
+                    <h2 className="font-semibold text-lg">What goes in</h2>
+                  </div>
+                  <ul className="space-y-4">
+                    {tool.inputs.map((input) => (
+                      <li key={input.id} className="flex gap-3">
+                        <CheckCircle2 className="size-4 text-primary mt-0.5 shrink-0" />
+                        <div>
+                          <p className="font-medium text-sm flex items-center gap-2">
+                            {input.label}
+                            {!input.required && (
+                              <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                                Optional
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            {input.description}
+                          </p>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+              <Card className="bg-primary/5 border-primary/20">
+                <CardContent className="p-6">
+                  <div className="flex items-center gap-2 mb-5">
+                    <FileOutput className="size-5 text-primary" />
+                    <h2 className="font-semibold text-lg">What comes out</h2>
+                  </div>
+                  <p className="text-sm font-medium mb-1">
+                    {tool.output.label}
+                  </p>
+                  <p className="text-xs text-muted-foreground mb-4">
+                    Format: {tool.output.format}
+                  </p>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground border-t pt-4">
+                    <ShieldCheck className="size-3.5" />
+                    Editable, audit-trailed
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          {/* Use cases + Out of scope */}
+          <section className="mt-20 sm:mt-24">
+            <div className="grid gap-10 lg:grid-cols-2">
+              <div>
+                <h2 className="text-2xl font-bold tracking-tight mb-6">
+                  When teams use this
+                </h2>
+                <ul className="space-y-3">
+                  {tool.useCases.map((uc, i) => (
+                    <li key={i} className="flex gap-3 text-sm">
+                      <CheckCircle2 className="size-4 text-primary mt-0.5 shrink-0" />
+                      <span className="text-muted-foreground leading-relaxed">
+                        {uc}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h2 className="text-2xl font-bold tracking-tight mb-6">
+                  What this tool does{" "}
+                  <em className="text-muted-foreground">not</em> do
+                </h2>
+                <ul className="space-y-3">
+                  {tool.outOfScope.map((s, i) => (
+                    <li key={i} className="flex gap-3 text-sm">
+                      <XCircle className="size-4 text-muted-foreground mt-0.5 shrink-0" />
+                      <span className="text-muted-foreground leading-relaxed">
+                        {s}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          {/* Personas */}
+          <section className="mt-20 sm:mt-24">
+            <h2 className="text-2xl sm:text-3xl font-bold text-center mb-10">
+              Built for
+            </h2>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
+              {tool.personas.map((persona) => {
+                const Icon = getIcon(persona.icon);
+                return (
+                  <Card
+                    key={persona.title}
+                    className="hover:border-primary/30 transition-colors"
+                  >
+                    <CardContent className="p-5">
+                      <Icon className="size-5 text-primary mb-3" />
+                      <h3 className="font-semibold text-sm mb-1.5">
+                        {persona.title}
+                      </h3>
+                      <p className="text-xs text-muted-foreground leading-relaxed">
+                        {persona.description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* FAQ */}
+          <section className="mt-20 sm:mt-24 max-w-3xl mx-auto">
+            <h2 className="text-2xl sm:text-3xl font-bold text-center mb-10">
+              Frequently asked questions
+            </h2>
+            <div className="grid sm:grid-cols-2 gap-5">
+              {tool.faqs.map((faq) => (
+                <Card key={faq.q}>
+                  <CardContent className="p-5">
+                    <h3 className="font-semibold text-sm mb-2">{faq.q}</h3>
+                    <p className="text-xs text-muted-foreground leading-relaxed">
+                      {faq.a}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          {/* Final CTA */}
+          <section className="mt-20 sm:mt-24">
+            <Card className="bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
+              <CardContent className="p-10 sm:p-14 text-center max-w-3xl mx-auto">
+                <div className="inline-flex items-center justify-center size-14 rounded-2xl bg-primary/15 text-primary mb-6">
+                  <Sparkles className="size-7" />
+                </div>
+                <h2 className="text-2xl sm:text-3xl font-bold mb-4">
+                  License {tool.shortName} for your team
+                </h2>
+                <p className="text-muted-foreground max-w-xl mx-auto mb-8 leading-relaxed">
+                  Run one free preview to see the output on your own document.
+                  To run it across your portfolio, integrate with your QMS, or
+                  license for your team — walk through the output with us in a
+                  30-min call.
+                </p>
+                <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+                  <Button size="lg" asChild>
+                    <a
+                      href={BOOK_DEMO_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <CalendarClock className="size-4 mr-2" />
+                      Book a 30-min demo
+                      <ArrowRight className="size-4 ml-2" />
+                    </a>
+                  </Button>
+                  <Button size="lg" variant="outline" asChild>
+                    <a href="#tool">Try it free first</a>
+                  </Button>
+                </div>
+                <p className="mt-4 text-xs text-muted-foreground">
+                  Sales-led license · Per-team pricing discussed on the call ·
+                  No self-serve checkout
+                </p>
+              </CardContent>
+            </Card>
+          </section>
+
+          {/* Related tools */}
+          <section className="mt-20 sm:mt-24">
+            <h2 className="text-lg font-semibold mb-6">Other SFDA tools</h2>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {otherTools.map((other) => {
+                const Icon = getIcon(other.icon);
+                return (
+                  <Link
+                    key={other.slug}
+                    href={`/sfda/${other.slug}`}
+                    className="group block"
+                  >
+                    <Card className="hover:border-primary/40 transition-colors">
+                      <CardContent className="p-5 flex gap-4">
+                        <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary shrink-0">
+                          <Icon className="size-5" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-semibold text-sm mb-1 inline-flex items-center gap-1.5">
+                            {other.shortName}
+                            <ArrowRight className="size-3.5 text-muted-foreground group-hover:text-primary group-hover:translate-x-0.5 transition-all" />
+                          </p>
+                          <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+                            {other.outcome}
+                          </p>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                );
+              })}
+            </div>
+            <div className="mt-6">
+              <Link
+                href="/sfda"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline underline-offset-4"
+              >
+                See all SFDA tools
+                <ArrowRight className="size-3.5" />
+              </Link>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/client/src/lib/sfda/tools.ts
+++ b/client/src/lib/sfda/tools.ts
@@ -1,0 +1,544 @@
+/**
+ * SFDA marketing tool registry. Powers the public /sfda hub and per-tool
+ * landing pages. Conversion model: each tool gets a small number of free
+ * runs (default 1). After the AHA moment, primary CTA shifts to "Book a
+ * 30-min demo" — license sold on the call, not self-serve.
+ */
+
+export interface SfdaToolInput {
+  id: string;
+  label: string;
+  description: string;
+  accept: string;
+  maxSize: number;
+  required: boolean;
+}
+
+export interface SfdaToolOutput {
+  label: string;
+  format: string;
+}
+
+export interface SfdaToolFeature {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface SfdaToolStep {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface SfdaToolPersona {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface SfdaToolFaq {
+  q: string;
+  a: string;
+}
+
+export interface SfdaTool {
+  slug: string;
+  name: string;
+  shortName: string;
+  headKeyword: string;
+  outcome: string;
+  description: string;
+  metaDescription: string;
+  icon: string;
+  badgeLabel: string;
+  ctaLabel: string;
+  inputs: SfdaToolInput[];
+  output: SfdaToolOutput;
+  features: SfdaToolFeature[];
+  steps: SfdaToolStep[];
+  useCases: string[];
+  outOfScope: string[];
+  personas: SfdaToolPersona[];
+  faqs: SfdaToolFaq[];
+}
+
+/** Where every "Book a demo" CTA points. Sales-led license conversion. */
+export const BOOK_DEMO_URL =
+  "https://calendly.com/talal-bytebeam/sfda-discovery";
+
+/** Default number of free runs per tool before the demo gate kicks in. */
+export const DEFAULT_FREE_USES = 1;
+
+const MB = 1024 * 1024;
+
+export const SFDA_TOOLS: SfdaTool[] = [
+  {
+    slug: "spc-pil-generator",
+    name: "SFDA SmPC & PIL Generator",
+    shortName: "SmPC & PIL Generator",
+    headKeyword: "SFDA SmPC generator",
+    outcome:
+      "Generate SFDA-aligned English SmPC and PIL drafts from your originator pack — in minutes, not weeks.",
+    description:
+      "Upload the originator SmPC and PIL plus your new-product data. The tool produces draft English SmPC and PIL aligned to SFDA Module 1.3 structure and GCC labelling expectations, ready for your regulatory team's review and sign-off.",
+    metaDescription:
+      "Generate SFDA-aligned English SmPC and PIL drafts from originator documents. Module 1.3-ready, editable DOCX output, built for KSA submissions.",
+    icon: "FileText",
+    badgeLabel: "SmPC & PIL Generator",
+    ctaLabel: "Generate draft SmPC + PIL",
+    inputs: [
+      {
+        id: "originator_smpc",
+        label: "Originator SmPC",
+        description: "EMA/EMC originator Summary of Product Characteristics",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+      {
+        id: "originator_pil",
+        label: "Originator PIL",
+        description: "EMA/EMC originator Patient Information Leaflet",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+      {
+        id: "product_data",
+        label: "New product data",
+        description:
+          "Brand name, MAH, manufacturer, excipients, pack sizes, storage conditions",
+        accept: ".pdf,.docx,.xlsx",
+        maxSize: 10 * MB,
+        required: true,
+      },
+      {
+        id: "stability_study",
+        label: "Stability study (optional)",
+        description: "Informs storage statement and shelf life",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: false,
+      },
+    ],
+    output: {
+      label: "Draft SmPC and PIL (English)",
+      format: "DOCX",
+    },
+    features: [
+      {
+        icon: "Shield",
+        title: "Authority-aligned",
+        description:
+          "Output structure follows SFDA Module 1.3 expectations and the EMA QRD-derived layout adopted across GCC.",
+      },
+      {
+        icon: "FileSearch",
+        title: "Originator-anchored",
+        description:
+          "Pulls structure and clinical content from the originator dossier — no blank-page guesswork.",
+      },
+      {
+        icon: "PenLine",
+        title: "Editable DOCX out",
+        description:
+          "Your QPPV gets a real Word file, not a locked PDF — finish sign-off in your normal review tools.",
+      },
+    ],
+    steps: [
+      {
+        icon: "Upload",
+        title: "Upload originator pack",
+        description:
+          "Drop in the originator SmPC + PIL. PDFs or DOCX, up to 25 MB each.",
+      },
+      {
+        icon: "ListChecks",
+        title: "Add new product data",
+        description:
+          "Brand, MAH, manufacturer, excipients, pack sizes, storage. Fields map to SFDA's expected sections.",
+      },
+      {
+        icon: "Download",
+        title: "Download SmPC + PIL drafts",
+        description:
+          "Editable DOCX, ready for your QPPV / RA review and final sign-off.",
+      },
+    ],
+    useCases: [
+      "Preparing Module 1.3 labelling documents for a new SFDA submission.",
+      "Building first-pass SmPC and PIL drafts for generic registrations.",
+      "Aligning labelling between originator EU pack and KSA local pack.",
+      "Out-licensing or in-licensing transfers where labelling needs adapting to KSA.",
+    ],
+    outOfScope: [
+      "Regulatory sign-off — your QPPV or RA lead reviews and approves.",
+      "Arabic translation — handled by the SmPC & PIL Arabic Translator.",
+      "Module 3 quality content — labelling artefacts only.",
+      "Promotional or marketing copy.",
+    ],
+    personas: [
+      {
+        icon: "Factory",
+        title: "Local Saudi manufacturers",
+        description:
+          "Generic and OTC manufacturers preparing high-volume Module 1.3 packages without scaling headcount.",
+      },
+      {
+        icon: "Globe",
+        title: "Foreign manufacturers entering KSA",
+        description:
+          "MAHs adapting an originator pack to the local market — first KSA submission without an in-house RA team.",
+      },
+      {
+        icon: "Users",
+        title: "RA consultancies",
+        description:
+          "Firms running 10+ submissions a year — replace draft cycles with same-day output across client portfolios.",
+      },
+      {
+        icon: "Building2",
+        title: "MNC affiliate RA teams",
+        description:
+          "Local affiliate teams under headcount pressure, scaling submission throughput without scaling people.",
+      },
+    ],
+    faqs: [
+      {
+        q: "Does the output meet SFDA's QRD-style template requirements?",
+        a: "The draft is structured to align with SFDA's Module 1.3 expectations and the EMA QRD-derived layout that GCC authorities have largely adopted. Final formatting and wording is your regulatory team's responsibility before submission.",
+      },
+      {
+        q: "Can I use this for innovator (new chemical entity) submissions?",
+        a: "Yes — but innovator submissions usually require bespoke sections beyond what an originator-anchored draft covers. Treat the output as a structural starting point and expect your team to author the originator-specific sections from scratch.",
+      },
+      {
+        q: "What happens to my source documents?",
+        a: "Files are processed inside your Bytebeam workspace, not stored externally. Audit trail is retained for compliance review and can be wiped on request.",
+      },
+      {
+        q: "How long does generation take?",
+        a: "Typical SmPC + PIL drafts return in 3–8 minutes depending on the complexity of the originator pack. You can stay on the page or come back via the dashboard.",
+      },
+      {
+        q: "Can the output go straight to submission?",
+        a: "No. The draft is a structural starting point that replaces 60–80% of the manual work. Your QPPV/RA lead must review and approve before any SFDA submission.",
+      },
+      {
+        q: "Does it handle pack-size, dosage form, or strength variations?",
+        a: "Yes. Provide the new product data sheet with the variants and the tool produces correctly populated SmPC fields for each. Multi-strength packs become a single coherent SmPC with the right sections expanded.",
+      },
+    ],
+  },
+  {
+    slug: "spc-pil-arabic-translator",
+    name: "SFDA Arabic SmPC & PIL Translator",
+    shortName: "Arabic SmPC & PIL Translator",
+    headKeyword: "SFDA PIL Arabic translation",
+    outcome:
+      "Translate English SmPC and PIL into SFDA-compliant Arabic with regulator-ready RTL formatting.",
+    description:
+      "Upload finalised English SmPC and PIL. The tool produces Arabic translations using SFDA-recognised regulatory phrasing, with RTL layout and bilingual section headings — ready for review by your Arabic-fluent reviewer.",
+    metaDescription:
+      "Translate SmPC and PIL to Arabic for SFDA submission. Regulatory-aware phrasing, RTL formatting, Saudi-specific terminology, editable DOCX out.",
+    icon: "Languages",
+    badgeLabel: "Arabic Translator",
+    ctaLabel: "Translate to Arabic",
+    inputs: [
+      {
+        id: "english_smpc",
+        label: "English SmPC",
+        description: "Finalised English Summary of Product Characteristics",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+      {
+        id: "english_pil",
+        label: "English PIL",
+        description: "Finalised English Patient Information Leaflet",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+    ],
+    output: {
+      label: "Arabic SmPC and PIL with RTL formatting",
+      format: "DOCX",
+    },
+    features: [
+      {
+        icon: "Languages",
+        title: "Regulatory Arabic, not generic translation",
+        description:
+          "Modern Standard Arabic with phrasing SFDA recognises. Avoids the calques and over-literal renderings that trigger Module 1.3 RFIs.",
+      },
+      {
+        icon: "AlignRight",
+        title: "RTL formatting built in",
+        description:
+          "Tables, lists, and section headings flip cleanly. No post-process reformatting in Word required.",
+      },
+      {
+        icon: "BookOpen",
+        title: "Section-aware",
+        description:
+          "SmPC and PIL section structure preserved. Bilingual headings if your local pack format requires them.",
+      },
+    ],
+    steps: [
+      {
+        icon: "FileUp",
+        title: "Upload English SmPC + PIL",
+        description:
+          "PDFs or DOCX. Final English versions, not drafts — translation aligns to your approved English text.",
+      },
+      {
+        icon: "Languages",
+        title: "Auto-translate with regulatory phrasing",
+        description:
+          "AI applies SFDA-accepted regulatory Arabic. Brand and scientific terms preserved with established transliterations.",
+      },
+      {
+        icon: "FileDown",
+        title: "Download Arabic DOCX",
+        description:
+          "Editable RTL Word file. Ready for your Arabic-fluent reviewer's sign-off.",
+      },
+    ],
+    useCases: [
+      "Producing the Arabic PIL required by SFDA for Module 1.3.",
+      "Aligning bilingual Arabic/English labelling for the KSA market.",
+      "Updating Arabic translations after a labelling variation.",
+      "Catch-up translation work after an English SmPC update from the MAH.",
+    ],
+    outOfScope: [
+      "Linguistic validation — readability testing with Arabic users is your team's responsibility.",
+      "Pictogram or layout artwork.",
+      "Translation of Module 3 quality content.",
+      "Free-form marketing or promotional translation.",
+    ],
+    personas: [
+      {
+        icon: "Factory",
+        title: "Manufacturers without in-house Arabic team",
+        description:
+          "Replace external translation-agency cycles. Same-day Arabic from the approved English source.",
+      },
+      {
+        icon: "Users",
+        title: "RA consultancies handling MAH portfolios",
+        description:
+          "Productize Arabic translation as a recurring service line, no per-project translation outsourcing.",
+      },
+      {
+        icon: "Globe",
+        title: "Foreign pharma entering KSA",
+        description:
+          "First Arabic SmPC + PIL package without hiring an Arabic regulatory writer.",
+      },
+      {
+        icon: "RefreshCw",
+        title: "Variation-heavy portfolios",
+        description:
+          "Every SmPC update needs an Arabic re-translation — automate the recurring overhead.",
+      },
+    ],
+    faqs: [
+      {
+        q: "Which Arabic register does the tool produce?",
+        a: "Modern Standard Arabic, using regulatory phrasing accepted by SFDA. Brand names and specific scientific terms are kept in their accepted Arabic transliteration where established.",
+      },
+      {
+        q: "Do you preserve formatting from the source document?",
+        a: "Section structure and tables are preserved. RTL flow is applied automatically. Final visual polish (font, kerning, page breaks) typically requires light DTP work.",
+      },
+      {
+        q: "Will SFDA accept this Arabic without further review?",
+        a: "No. Your Arabic-fluent reviewer must read and approve before submission. The tool replaces the time-intensive first-pass translation, not the regulatory review.",
+      },
+      {
+        q: "Can I translate just the PIL, or just the SmPC?",
+        a: "Both files are required by default for cross-document consistency. If you only have one, contact us — single-document workflows are supported on the Pro plan.",
+      },
+      {
+        q: "How does it handle SFDA-specific terminology?",
+        a: "A maintained glossary of SFDA-accepted regulatory Arabic terms is applied consistently across both documents. Where the regulator publishes a preferred translation, that wording is used.",
+      },
+      {
+        q: "How long does translation take?",
+        a: "Typical SmPC + PIL Arabic translation returns in 5–10 minutes depending on document length. Drafts save automatically to your dashboard.",
+      },
+    ],
+  },
+  {
+    slug: "dossier-gap-analysis",
+    name: "SFDA Dossier Gap Analysis",
+    shortName: "Dossier Gap Analysis",
+    headKeyword: "SFDA dossier review",
+    outcome:
+      "Catch SFDA labelling gaps before you submit — section-by-section gap report ranked by submission risk.",
+    description:
+      "Upload your English PIL, Arabic PIL, and English SmPC. The tool runs a structured comparison against SFDA Module 1.3 expectations and GCC labelling guidance, returning a per-section gap report ranked by likelihood of triggering an RFI or rejection.",
+    metaDescription:
+      "Pre-submission gap analysis for SFDA SmPC and PIL packs. Catches labelling, translation, and section-completeness gaps. Severity-ranked report.",
+    icon: "SearchCheck",
+    badgeLabel: "Gap Analysis",
+    ctaLabel: "Run gap analysis",
+    inputs: [
+      {
+        id: "english_pil",
+        label: "English PIL",
+        description: "Patient Information Leaflet, English",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+      {
+        id: "arabic_pil",
+        label: "Arabic PIL",
+        description: "Patient Information Leaflet, Arabic",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+      {
+        id: "english_smpc",
+        label: "English SmPC",
+        description: "Summary of Product Characteristics, English",
+        accept: ".pdf,.docx",
+        maxSize: 25 * MB,
+        required: true,
+      },
+      {
+        id: "product_data",
+        label: "New drug data",
+        description: "Brand name, MAH, manufacturer, excipients, pack sizes",
+        accept: ".pdf,.docx,.xlsx",
+        maxSize: 10 * MB,
+        required: true,
+      },
+    ],
+    output: {
+      label: "Section-by-section gap report with severity ranking",
+      format: "PDF + on-screen viewer",
+    },
+    features: [
+      {
+        icon: "AlertTriangle",
+        title: "Severity-ranked findings",
+        description:
+          "Each gap tagged Critical (likely RFI/rejection), Major (probable RFI), or Minor (recommended fix).",
+      },
+      {
+        icon: "GitCompare",
+        title: "Cross-document checks",
+        description:
+          "Validates Arabic PIL against the English source and against the English SmPC — catches drift between artefacts.",
+      },
+      {
+        icon: "BookCheck",
+        title: "Guidance-grounded",
+        description:
+          "Findings cite the specific SFDA / GCC guidance section that drives each gap. No vague flags.",
+      },
+    ],
+    steps: [
+      {
+        icon: "Upload",
+        title: "Upload your three artefacts",
+        description:
+          "English PIL, Arabic PIL, English SmPC — plus the product data sheet.",
+      },
+      {
+        icon: "Search",
+        title: "Auto-comparison runs",
+        description:
+          "Section-by-section pass against SFDA Module 1.3 + GCC labelling expectations.",
+      },
+      {
+        icon: "FileText",
+        title: "Get severity-ranked report",
+        description:
+          "Critical / Major / Minor findings with citation to the SFDA guidance that drives each.",
+      },
+    ],
+    useCases: [
+      "Pre-submission self-check to reduce SFDA Requests for Information.",
+      "Auditing a partner CMO's labelling output before signing off.",
+      "Variation impact assessment before submitting a Type IB or Type II.",
+      "QC sweep before a regulatory inspection.",
+    ],
+    outOfScope: [
+      "Module 3 quality content — gap analysis covers labelling artefacts only.",
+      "Regulatory sign-off — final review and submission decisions remain with your QPPV/RA lead.",
+      "Pricing or commercial review.",
+      "Translation correctness — use the Arabic Translator for that.",
+    ],
+    personas: [
+      {
+        icon: "ShieldCheck",
+        title: "RA leads pre-submission",
+        description:
+          "Last-mile QC before the submission button. Catch gaps that cost weeks in RFI cycles.",
+      },
+      {
+        icon: "Eye",
+        title: "QPPVs auditing CMO output",
+        description:
+          "Validate labelling artefacts received from a contract manufacturer or partner agency.",
+      },
+      {
+        icon: "Factory",
+        title: "Manufacturers running variations",
+        description:
+          "Type IB/II changes — assess labelling impact before formal submission.",
+      },
+      {
+        icon: "Users",
+        title: "RA consultancies serving multiple MAHs",
+        description:
+          "Standardised QC layer across diverse client portfolios.",
+      },
+    ],
+    faqs: [
+      {
+        q: "What does 'severity ranking' mean?",
+        a: "Each gap is tagged Critical (likely RFI or rejection), Major (probable RFI), or Minor (recommended fix). The ranking is grounded in published SFDA guidance and common Module 1.3 deficiency patterns observed in real submissions.",
+      },
+      {
+        q: "Will it find issues a human reviewer would miss?",
+        a: "It is a complement, not a replacement. Use it for completeness sweeps; rely on your reviewer for clinical and pharmacological judgement.",
+      },
+      {
+        q: "Does it check the Arabic against the English?",
+        a: "Yes. The tool detects drift between the Arabic PIL and the English source, including missing sections, terminology mismatches, and structural inconsistencies.",
+      },
+      {
+        q: "How long does an analysis take?",
+        a: "Typical full-pack gap analysis runs in 2–5 minutes. Reports are saved to your dashboard for re-review.",
+      },
+      {
+        q: "Can I run it on a partial pack?",
+        a: "All three artefacts are required for a meaningful comparison. If you only have an SmPC, the gap analysis cannot validate cross-document consistency.",
+      },
+      {
+        q: "Can I export the report for my QMS?",
+        a: "Yes. Reports export as PDF with citations and severity tags suitable for QMS evidence and inspection-ready records.",
+      },
+    ],
+  },
+];
+
+export function getSfdaTool(slug: string): SfdaTool | undefined {
+  return SFDA_TOOLS.find((t) => t.slug === slug);
+}
+
+export function getAllSfdaToolSlugs(): string[] {
+  return SFDA_TOOLS.map((t) => t.slug);
+}
+
+export function getOtherSfdaTools(slug: string): SfdaTool[] {
+  return SFDA_TOOLS.filter((t) => t.slug !== slug);
+}

--- a/client/src/pages/sfda/dossier-gap-analysis.tsx
+++ b/client/src/pages/sfda/dossier-gap-analysis.tsx
@@ -1,0 +1,7 @@
+import SfdaToolPage from "@/components/sfda/SfdaToolPage";
+import { getSfdaTool } from "@/lib/sfda/tools";
+
+export default function SfdaDossierGapAnalysisPage() {
+  const tool = getSfdaTool("dossier-gap-analysis")!;
+  return <SfdaToolPage tool={tool} />;
+}

--- a/client/src/pages/sfda/index.tsx
+++ b/client/src/pages/sfda/index.tsx
@@ -1,0 +1,245 @@
+import { Link } from "wouter";
+import * as Icons from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowRight,
+  ShieldCheck,
+  Clock,
+  FileCheck2,
+  Sparkles,
+  CalendarClock,
+} from "lucide-react";
+import { motion } from "framer-motion";
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import SEO from "@/components/SEO";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { BOOK_DEMO_URL, SFDA_TOOLS } from "@/lib/sfda/tools";
+
+const PAGE_URL = "https://bytebeam.co/sfda";
+
+const trustPoints = [
+  {
+    icon: ShieldCheck,
+    title: "SFDA-aligned by design",
+    description:
+      "Outputs follow Module 1.3 structure and the QRD-derived layout adopted across GCC.",
+  },
+  {
+    icon: Clock,
+    title: "Hours, not weeks",
+    description:
+      "Replace the 60–80% of labelling work that's mechanical. Keep the regulatory judgment with your team.",
+  },
+  {
+    icon: FileCheck2,
+    title: "Editable, audit-ready",
+    description:
+      "DOCX out for QPPV review. Audit trail retained for inspection-ready records.",
+  },
+];
+
+export default function SfdaHubPage() {
+  const structuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: "https://bytebeam.co",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "SFDA Tools",
+          item: PAGE_URL,
+        },
+      ],
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      name: "ByteBeam SFDA Regulatory Tools",
+      description:
+        "Three AI agents for SFDA labelling work — SmPC and PIL generation, Arabic translation, and dossier gap analysis.",
+      url: PAGE_URL,
+      hasPart: SFDA_TOOLS.map((tool) => ({
+        "@type": "SoftwareApplication",
+        name: tool.name,
+        url: `${PAGE_URL}/${tool.slug}`,
+        applicationCategory: "BusinessApplication",
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <SEO
+        title="SFDA Regulatory Tools — SmPC, PIL, Gap Analysis | ByteBeam"
+        description="Three AI agents for SFDA Module 1.3 labelling work. Generate SmPC and PIL drafts, translate to Arabic, and run dossier gap analysis — built for KSA submissions."
+        keywords="SFDA, SFDA tools, Saudi Food and Drug Authority, SmPC generator, PIL Arabic translation, dossier gap analysis, Module 1.3, GCC labelling, drug registration Saudi Arabia, regulatory affairs pharma"
+        canonical={PAGE_URL}
+        ogUrl={PAGE_URL}
+        structuredData={structuredData}
+      />
+
+      <Navigation />
+
+      <main className="min-h-screen pt-20 pb-12 bg-gradient-to-b from-slate-50 to-white">
+        <div className="container-custom">
+          {/* Hero */}
+          <motion.section
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="relative text-center max-w-3xl mx-auto pt-8 pb-12"
+          >
+            <Badge variant="secondary" className="gap-1.5 mb-6">
+              <Sparkles className="size-3 text-primary" />
+              SFDA Regulatory Tools
+            </Badge>
+            <h1 className="text-3xl sm:text-5xl font-bold tracking-tight leading-[1.1] mb-4">
+              The SFDA labelling toolkit, built into one workflow
+            </h1>
+            <p className="text-base sm:text-lg text-muted-foreground leading-relaxed mb-8">
+              Three tools that replace the mechanical 60–80% of SFDA Module 1.3
+              labelling work. Built around how Saudi RA teams actually submit.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Button size="lg" asChild>
+                <Link href={`/sfda/${SFDA_TOOLS[0].slug}`}>
+                  Try a tool free
+                  <ArrowRight className="size-4 ml-2" />
+                </Link>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <a
+                  href={BOOK_DEMO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <CalendarClock className="size-4 mr-2" />
+                  Book a 30-min demo
+                </a>
+              </Button>
+            </div>
+            <p className="mt-4 text-xs text-muted-foreground">
+              One free run per tool · License sold via 30-min walkthrough
+            </p>
+          </motion.section>
+
+          {/* Tool cards */}
+          <section className="max-w-5xl mx-auto pb-16">
+            <div className="grid gap-5 md:grid-cols-3">
+              {SFDA_TOOLS.map((tool, index) => {
+                const Icon =
+                  (Icons as unknown as Record<string, LucideIcon>)[tool.icon] ??
+                  Icons.Wrench;
+                return (
+                  <Link
+                    key={tool.slug}
+                    href={`/sfda/${tool.slug}`}
+                    className="group block"
+                  >
+                    <Card className="h-full hover:border-primary/40 hover:shadow-md transition-all">
+                      <CardContent className="p-6 flex flex-col h-full">
+                        <div className="flex items-start justify-between mb-4">
+                          <div className="flex size-11 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                            <Icon className="size-5" />
+                          </div>
+                          <span className="text-xs font-mono text-muted-foreground/60">
+                            0{index + 1}
+                          </span>
+                        </div>
+                        <h2 className="text-lg font-semibold mb-2 inline-flex items-center gap-1.5 group-hover:text-primary transition-colors">
+                          {tool.shortName}
+                          <ArrowRight className="size-3.5 text-muted-foreground group-hover:text-primary group-hover:translate-x-0.5 transition-all" />
+                        </h2>
+                        <p className="text-sm text-muted-foreground leading-relaxed flex-1">
+                          {tool.outcome}
+                        </p>
+                        <div className="mt-5 pt-4 border-t flex items-center justify-between text-xs text-muted-foreground">
+                          <span className="inline-flex items-center gap-1.5">
+                            <FileCheck2 className="size-3.5" />
+                            {tool.output.format}
+                          </span>
+                          <span className="font-medium text-foreground">
+                            Try it →
+                          </span>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Trust strip */}
+          <section className="max-w-5xl mx-auto py-12 border-t">
+            <div className="grid gap-6 md:grid-cols-3">
+              {trustPoints.map((point) => (
+                <Card key={point.title}>
+                  <CardContent className="p-6">
+                    <div className="inline-flex items-center justify-center size-11 rounded-lg bg-primary/10 text-primary mb-4">
+                      <point.icon className="size-5" />
+                    </div>
+                    <h3 className="font-semibold text-base mb-1.5">
+                      {point.title}
+                    </h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      {point.description}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          {/* Final CTA */}
+          <section className="max-w-3xl mx-auto py-16 text-center">
+            <div className="inline-flex items-center justify-center size-14 rounded-2xl bg-primary/10 text-primary mb-6">
+              <Sparkles className="size-7" />
+            </div>
+            <h2 className="text-2xl sm:text-3xl font-bold mb-4">
+              Built for the labelling work that doesn't scale by hiring.
+            </h2>
+            <p className="text-muted-foreground max-w-xl mx-auto mb-8 leading-relaxed">
+              Variation cycles, Arabic re-translation, pre-submission QC — the
+              mechanical work that eats senior RA time. ByteBeam ships the
+              agents; your QPPV signs off. Walk through the output with us, then
+              license it for your team.
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+              <Button size="lg" asChild>
+                <a
+                  href={BOOK_DEMO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <CalendarClock className="size-4 mr-2" />
+                  Book a 30-min demo
+                  <ArrowRight className="size-4 ml-2" />
+                </a>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <Link href={`/sfda/${SFDA_TOOLS[0].slug}`}>
+                  Try a tool free first
+                </Link>
+              </Button>
+            </div>
+            <p className="mt-4 text-xs text-muted-foreground">
+              Sales-led license · Per-team pricing discussed on the call
+            </p>
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/sfda/spc-pil-arabic-translator.tsx
+++ b/client/src/pages/sfda/spc-pil-arabic-translator.tsx
@@ -1,0 +1,7 @@
+import SfdaToolPage from "@/components/sfda/SfdaToolPage";
+import { getSfdaTool } from "@/lib/sfda/tools";
+
+export default function SfdaArabicTranslatorPage() {
+  const tool = getSfdaTool("spc-pil-arabic-translator")!;
+  return <SfdaToolPage tool={tool} />;
+}

--- a/client/src/pages/sfda/spc-pil-generator.tsx
+++ b/client/src/pages/sfda/spc-pil-generator.tsx
@@ -1,0 +1,7 @@
+import SfdaToolPage from "@/components/sfda/SfdaToolPage";
+import { getSfdaTool } from "@/lib/sfda/tools";
+
+export default function SfdaSpcPilGeneratorPage() {
+  const tool = getSfdaTool("spc-pil-generator")!;
+  return <SfdaToolPage tool={tool} />;
+}

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -115,6 +115,12 @@ const ROUTES = [
   '/blog/no-code-document-automation-regulatory-teams-2026',
   '/blog/intelligent-document-processing-business-guide-2026',
   '/blog/automating-invoice-processing-2026',
+
+  // SFDA Regulatory Tools
+  '/sfda',
+  '/sfda/spc-pil-generator',
+  '/sfda/spc-pil-arabic-translator',
+  '/sfda/dossier-gap-analysis',
 ];
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -172,6 +172,12 @@ export const routesToPrerender = [
   "/parsli/document/bank-statements",
   "/parsli/document/contracts",
   "/parsli/document/forms",
+
+  // SFDA Regulatory Tools
+  "/sfda",
+  "/sfda/spc-pil-generator",
+  "/sfda/spc-pil-arabic-translator",
+  "/sfda/dossier-gap-analysis",
 ];
 
 export default defineConfig({


### PR DESCRIPTION
… analysis)

Three AI-tool landing pages under /sfda with sales-led demo CTA:
- /sfda hub
- /sfda/spc-pil-generator
- /sfda/spc-pil-arabic-translator
- /sfda/dossier-gap-analysis

Free preview rate-limited to 1 run per tool (localStorage). After the AHA moment, primary CTA shifts to "Book a 30-min demo" — license sold on the call, not self-serve.

Includes /feed.xml RSS feed and sitemap.xml + prerender list updates.