### PR TITLE
Fix SPA catchall rewrite (broken sitewide on production)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -51,7 +51,7 @@
       "destination": "/parsli/:path*"
     },
     {
-      "source": "/:path*",
+      "source": "/((?!api/|assets/|_next/|.*\\..*).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
The /:path* rewrite to /index.html stopped catching client-side routes — all non-root paths (/tools, /solutions, /about, /sfda, etc.) were returning 404 from Vercel. Likely a path-to-regexp + cleanUrls interaction.

Switch to an explicit regex catchall that excludes API, asset, and file-extension paths (so static files like sitemap.xml and feed.xml keep serving directly).