### PR TITLE
Drop cleanUrls and simplify SPA catchall to /(.*)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist/public",
-  "cleanUrls": true,
   "trailingSlash": false,
   "redirects": [
     {
@@ -51,7 +50,7 @@
       "destination": "/parsli/:path*"
     },
     {
-      "source": "/((?!api/|assets/|_next/|.*\\..*).*)",
+      "source": "/(.*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
The negative-lookahead regex from the previous fix didn't catch /sfda in production — paths still 404'd. Going to the canonical Vite + Vercel SPA pattern: remove cleanUrls (which interferes with rewrite resolution) and use a plain /(.*) catchall.

Static files (sitemap.xml, feed.xml, /assets/*) keep serving directly because Vercel's file-system check has priority over rewrites.