### PR TITLE
Fix ESM module resolution for SFDA Vercel function

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -21,7 +21,19 @@ export const config = {
   maxDuration: 300,
 };
 
+console.log("[api/index] cold start: module loaded");
+
 const app = express();
+
+// Per-request trace log for SFDA endpoints — shows up in Vercel runtime logs
+app.use("/api/tools/sfda", (req, _res, next) => {
+  const files = (req.body as { files?: Array<{ inputId?: string; fileName?: string }> })?.files;
+  const summary = Array.isArray(files)
+    ? files.map((f) => `${f?.inputId}:${f?.fileName}`).join(",")
+    : "(no files)";
+  console.log(`[sfda] ${req.method} ${req.url}  files=[${summary}]`);
+  next();
+});
 
 // Match the local server's body limit so SFDA base64 file uploads pass through.
 app.use(express.json({ limit: "60mb" }));

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
+import { registerRoutes } from "./routes.js";
+import { setupVite, serveStatic, log } from "./vite.js";
 import path from "path";
 import fs from "fs";
 

--- a/server/lib/guidelines/index.ts
+++ b/server/lib/guidelines/index.ts
@@ -12,7 +12,7 @@
 
 import { readFile } from "fs/promises";
 import { join } from "path";
-import { extractTextFromPdf } from "../document/pdf-parser";
+import { extractTextFromPdf } from "../document/pdf-parser.js";
 
 let cachedGuidance: string | null = null;
 let cachedTemplate: string | null = null;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,8 +1,8 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage";
-import { insertLeadSchema } from "@shared/schema";
-import { registerToolRoutes } from "./routes/tools";
+import { storage } from "./storage.js";
+import { insertLeadSchema } from "../shared/schema.js";
+import { registerToolRoutes } from "./routes/tools.js";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Contact form submission endpoint

--- a/server/routes/tools.ts
+++ b/server/routes/tools.ts
@@ -1,8 +1,8 @@
 import type { Express, Request, Response } from "express";
-import { aiToolsLimiter, getRateLimitInfo } from "../middleware/rateLimit";
-import * as openRouterService from "../services/openrouter.service";
-import * as sfdaService from "../services/sfda";
-import type { SfdaUploadedFile } from "../services/sfda";
+import { aiToolsLimiter, getRateLimitInfo } from "../middleware/rateLimit.js";
+import * as openRouterService from "../services/openrouter.service.js";
+import * as sfdaService from "../services/sfda/index.js";
+import type { SfdaUploadedFile } from "../services/sfda/index.js";
 
 /**
  * Register all tool-related API routes

--- a/server/services/sfda/dossier-gap-analysis.ts
+++ b/server/services/sfda/dossier-gap-analysis.ts
@@ -5,14 +5,14 @@
  * tracking). Prompts and orchestration are unchanged.
  */
 
-import { generateText, type Message } from "../../lib/openrouter";
+import { generateText, type Message } from "../../lib/openrouter.js";
 import {
   extractTextFromPdf,
   base64ToBuffer,
-} from "../../lib/document/pdf-parser";
-import { extractTextFromDocx } from "../../lib/document/docx-parser";
-import { getFullTemplate, getFullGuidance } from "../../lib/guidelines";
-import type { SfdaUploadedFile, SfdaToolResult } from "./types";
+} from "../../lib/document/pdf-parser.js";
+import { extractTextFromDocx } from "../../lib/document/docx-parser.js";
+import { getFullTemplate, getFullGuidance } from "../../lib/guidelines/index.js";
+import type { SfdaUploadedFile, SfdaToolResult } from "./types.js";
 
 interface RunGapAnalysisOptions {
   storageConditions?: string;

--- a/server/services/sfda/index.ts
+++ b/server/services/sfda/index.ts
@@ -3,8 +3,8 @@
  * and the shared types so route handlers have a single import surface.
  */
 
-export type { SfdaUploadedFile, SfdaToolResult } from "./types";
-export { isOpenRouterConfigured } from "../../lib/openrouter";
-export { generateSpcPil } from "./spc-pil-generator";
-export { translateSpcPilToArabic } from "./spc-pil-arabic-translator";
-export { runDossierGapAnalysis } from "./dossier-gap-analysis";
+export type { SfdaUploadedFile, SfdaToolResult } from "./types.js";
+export { isOpenRouterConfigured } from "../../lib/openrouter.js";
+export { generateSpcPil } from "./spc-pil-generator.js";
+export { translateSpcPilToArabic } from "./spc-pil-arabic-translator.js";
+export { runDossierGapAnalysis } from "./dossier-gap-analysis.js";

--- a/server/services/sfda/spc-pil-arabic-translator.ts
+++ b/server/services/sfda/spc-pil-arabic-translator.ts
@@ -5,18 +5,18 @@
  * Prompts and orchestration are unchanged.
  */
 
-import { generateText } from "../../lib/openrouter";
+import { generateText } from "../../lib/openrouter.js";
 import {
   extractTextFromPdf,
   base64ToBuffer,
-} from "../../lib/document/pdf-parser";
-import { extractTextFromDocx } from "../../lib/document/docx-parser";
+} from "../../lib/document/pdf-parser.js";
+import { extractTextFromDocx } from "../../lib/document/docx-parser.js";
 import {
   getSfdaPilArabicTemplate,
   getGccPilGuidance,
   getSpcGuidelines,
-} from "../../lib/guidelines";
-import type { SfdaUploadedFile, SfdaToolResult } from "./types";
+} from "../../lib/guidelines/index.js";
+import type { SfdaUploadedFile, SfdaToolResult } from "./types.js";
 
 export async function translateSpcPilToArabic(
   files: SfdaUploadedFile[]

--- a/server/services/sfda/spc-pil-generator.ts
+++ b/server/services/sfda/spc-pil-generator.ts
@@ -6,17 +6,17 @@
  * are unchanged — this is the IP that drives output quality.
  */
 
-import { generateText } from "../../lib/openrouter";
+import { generateText } from "../../lib/openrouter.js";
 import {
   extractTextFromPdf,
   base64ToBuffer,
-} from "../../lib/document/pdf-parser";
+} from "../../lib/document/pdf-parser.js";
 import {
   prepareImageForVision,
   isImageMimeType,
-} from "../../lib/document/image-processor";
-import { getPilGuidelines, getSpcGuidelines } from "../../lib/guidelines";
-import type { SfdaUploadedFile, SfdaToolResult } from "./types";
+} from "../../lib/document/image-processor.js";
+import { getPilGuidelines, getSpcGuidelines } from "../../lib/guidelines/index.js";
+import type { SfdaUploadedFile, SfdaToolResult } from "./types.js";
 
 export async function generateSpcPil(
   files: SfdaUploadedFile[]
@@ -30,7 +30,7 @@ export async function generateSpcPil(
     } else if (isImageMimeType(file.mimeType)) {
       inputTexts[file.inputId] = prepareImageForVision(file.base64, file.mimeType);
     } else if (file.mimeType.includes("wordprocessingml")) {
-      const { extractTextFromDocx } = await import("../../lib/document/docx-parser");
+      const { extractTextFromDocx } = await import("../../lib/document/docx-parser.js");
       inputTexts[file.inputId] = await extractTextFromDocx(buffer);
     }
   }

--- a/server/services/sfda/types.ts
+++ b/server/services/sfda/types.ts
@@ -14,4 +14,4 @@ export interface SfdaToolResult {
   model: string;
 }
 
-export { isOpenRouterConfigured } from "../../lib/openrouter";
+export { isOpenRouterConfigured } from "../../lib/openrouter.js";

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { type User, type InsertUser, type Lead, type InsertLead } from "@shared/schema";
+import { type User, type InsertUser, type Lead, type InsertLead } from "../shared/schema.js";
 import { randomUUID } from "crypto";
 
 // modify the interface with any CRUD methods

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+import viteConfig from "../vite.config.js";
 import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();


### PR DESCRIPTION
## Why production still 500s after PR #7

PR #7 shipped the SFDA pipeline but the function crashed at cold start with `ERR_UNSUPPORTED_DIR_IMPORT` / `ERR_MODULE_NOT_FOUND`. Live Vercel logs traced it to a project-wide ESM resolution mismatch: tsconfig uses \`\"moduleResolution\":\"bundler\"\` (extensionless imports OK), but Vercel's runtime is strict ESM (\`\"type\":\"module\"\`) and didn't bundle the function — so every relative import without \`.js\` blew up at module load.

## What this PR changes

- Add \`.js\` extension to every relative import across \`server/\` and \`api/\` (~10 files via a one-shot Python script).
- Fix directory imports the script flattened to non-existent \`.js\` files: \`lib/guidelines.js\` → \`lib/guidelines/index.js\` (3 services), \`services/sfda.js\` → \`services/sfda/index.js\` (tools.ts).
- Add \`.js\` to the dynamic mammoth import in spc-pil-generator.
- Replace \`@shared/schema\` alias with \`../shared/schema.js\` — Vercel @vercel/node doesn't resolve tsconfig path aliases at runtime without bundling.
- Add cold-start log + per-request trace log under \`/api/tools/sfda\` so any next failure shows up labelled in Vercel runtime logs.

## After merge

1. Vercel auto-deploys on merge to \`main\`.
2. \`bytebeam.co/sfda/spc-pil-generator\` should now reach the function. Cold-start log \`[api/index] cold start: module loaded\` will appear in runtime logs, then \`[sfda] POST /api/tools/sfda/spc-pil-generator files=[...]\` per request.
3. If it still 500s, the trace logs will show exactly where in the pipeline it fails (PDF parse, guidelines load, OpenRouter call).