### PR TITLE
Split SFDA output into per-document cards with DOCX download

### DIFF
--- a/client/src/components/sfda/SfdaToolDemo.tsx
+++ b/client/src/components/sfda/SfdaToolDemo.tsx
@@ -12,6 +12,7 @@ import {
   Copy,
   Check,
   Download,
+  FileText,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -22,6 +23,10 @@ import {
   DEFAULT_FREE_USES,
   type SfdaToolInput,
 } from "@/lib/sfda/tools";
+import {
+  markdownToDocxBlob,
+  triggerDocxDownload,
+} from "@/lib/sfda/markdown-to-docx";
 
 interface UploadedFile {
   inputId: string;
@@ -29,6 +34,13 @@ interface UploadedFile {
 }
 
 type DemoState = "idle" | "processing" | "done" | "blocked" | "error";
+
+interface SfdaDocument {
+  id: string;
+  title: string;
+  markdown: string;
+  rtl?: boolean;
+}
 
 interface SfdaToolDemoProps {
   toolSlug: string;
@@ -75,8 +87,94 @@ function fileToBase64(file: File): Promise<string> {
 }
 
 function endpointForSlug(slug: string): string {
-  // Maps registry slug → server route
   return `/api/tools/sfda/${slug}`;
+}
+
+interface DocumentCardProps {
+  doc: SfdaDocument;
+  toolSlug: string;
+  index: number;
+}
+
+function DocumentCard({ doc, toolSlug, index }: DocumentCardProps) {
+  const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(doc.markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // ignore — clipboard may be unavailable
+    }
+  }, [doc.markdown]);
+
+  const handleDownload = useCallback(async () => {
+    setDownloading(true);
+    try {
+      const blob = await markdownToDocxBlob(doc.markdown, {
+        title: doc.title,
+        rtl: doc.rtl,
+      });
+      triggerDocxDownload(blob, `${toolSlug}-${doc.id}.docx`);
+    } catch (err) {
+      console.error("DOCX generation failed:", err);
+    } finally {
+      setDownloading(false);
+    }
+  }, [doc, toolSlug]);
+
+  return (
+    <div className="rounded-xl border bg-card overflow-hidden">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-5 py-4 border-b bg-muted/40">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="inline-flex items-center justify-center size-9 rounded-lg bg-primary/10 text-primary shrink-0">
+            <FileText className="size-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[10px] font-mono text-muted-foreground/60 uppercase tracking-wider">
+              Document {index + 1}
+            </p>
+            <h4 className="font-semibold text-sm truncate" dir={doc.rtl ? "rtl" : "ltr"}>
+              {doc.title}
+            </h4>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button variant="outline" size="sm" onClick={handleCopy} className="gap-1.5">
+            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleDownload}
+            disabled={downloading}
+            className="gap-1.5"
+          >
+            {downloading ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Download className="size-3.5" />
+            )}
+            .docx
+          </Button>
+        </div>
+      </div>
+      <div
+        className={cn(
+          "prose prose-sm max-w-none p-5 max-h-[420px] overflow-auto",
+          "prose-headings:font-semibold prose-headings:tracking-tight",
+          "prose-h1:text-xl prose-h2:text-lg prose-h3:text-base",
+          "prose-h2:mt-6 prose-h3:mt-4 prose-p:leading-relaxed",
+          "prose-li:my-1 prose-hr:my-5 prose-strong:text-foreground"
+        )}
+        dir={doc.rtl ? "rtl" : "ltr"}
+      >
+        <ReactMarkdown>{doc.markdown}</ReactMarkdown>
+      </div>
+    </div>
+  );
 }
 
 export default function SfdaToolDemo({
@@ -93,9 +191,8 @@ export default function SfdaToolDemo({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const [usageCount, setUsageCount] = useState(0);
-  const [resultMarkdown, setResultMarkdown] = useState<string>("");
+  const [documents, setDocuments] = useState<SfdaDocument[]>([]);
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [copied, setCopied] = useState(false);
   const fileRefs = useRef<Record<string, HTMLInputElement | null>>({});
 
   useEffect(() => {
@@ -147,10 +244,9 @@ export default function SfdaToolDemo({
     if (!allRequiredUploaded || state === "processing") return;
     setState("processing");
     setErrorMessage("");
-    setResultMarkdown("");
+    setDocuments([]);
 
     try {
-      // Encode every uploaded file (required + optional) as base64
       const payload = await Promise.all(
         Object.values(files).map(async (uf) => ({
           inputId: uf.inputId,
@@ -178,10 +274,12 @@ export default function SfdaToolDemo({
       }
 
       const data = await resp.json();
-      const md = typeof data?.markdown === "string" ? data.markdown : "";
-      if (!md) throw new Error("Empty response from AI service.");
+      const docs = Array.isArray(data?.documents) ? (data.documents as SfdaDocument[]) : null;
+      if (!docs || docs.length === 0) {
+        throw new Error("Empty response from AI service.");
+      }
 
-      setResultMarkdown(md);
+      setDocuments(docs);
       try {
         const next = usageCount + 1;
         localStorage.setItem(getStorageKey(toolSlug), String(next));
@@ -202,34 +300,10 @@ export default function SfdaToolDemo({
   const handleResetForRetry = useCallback(() => {
     setFiles({});
     setErrors({});
-    setResultMarkdown("");
+    setDocuments([]);
     setErrorMessage("");
     setState(usageCount >= freeUses ? "blocked" : "idle");
   }, [usageCount, freeUses]);
-
-  const handleCopy = useCallback(async () => {
-    if (!resultMarkdown) return;
-    try {
-      await navigator.clipboard.writeText(resultMarkdown);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
-    } catch {
-      // ignore
-    }
-  }, [resultMarkdown]);
-
-  const handleDownload = useCallback(() => {
-    if (!resultMarkdown) return;
-    const blob = new Blob([resultMarkdown], { type: "text/markdown;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${toolSlug}.md`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  }, [resultMarkdown, toolSlug]);
 
   // ─── Blocked ───
   if (state === "blocked") {
@@ -267,37 +341,32 @@ export default function SfdaToolDemo({
     );
   }
 
-  // ─── Done — show real output ───
+  // ─── Done — render each document in its own card ───
   if (state === "done") {
     return (
       <Card>
         <CardContent className="p-6 sm:p-8">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5 pb-5 border-b">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
             <div className="flex items-center gap-3">
               <div className="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 text-primary shrink-0">
                 <CheckCircle2 className="size-5" />
               </div>
               <div>
                 <p className="text-xs font-semibold uppercase tracking-wider text-primary">
-                  Preview ready
+                  Preview ready · {documents.length} document{documents.length === 1 ? "" : "s"}
                 </p>
                 <h3 className="text-base font-semibold">{toolName} — output</h3>
               </div>
             </div>
-            <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={handleCopy} className="gap-2">
-                {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-                {copied ? "Copied" : "Copy"}
-              </Button>
-              <Button variant="outline" size="sm" onClick={handleDownload} className="gap-2">
-                <Download className="size-4" />
-                .md
-              </Button>
-            </div>
+            <Button variant="outline" size="sm" onClick={handleResetForRetry}>
+              Done
+            </Button>
           </div>
 
-          <div className="prose prose-sm max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg prose-h2:mt-8 prose-h3:mt-6 prose-p:leading-relaxed prose-li:my-1 prose-hr:my-6 prose-strong:text-foreground bg-muted/30 rounded-lg p-5 sm:p-6 max-h-[600px] overflow-auto border">
-            <ReactMarkdown>{resultMarkdown}</ReactMarkdown>
+          <div className="space-y-4">
+            {documents.map((doc, i) => (
+              <DocumentCard key={doc.id} doc={doc} toolSlug={toolSlug} index={i} />
+            ))}
           </div>
 
           <div className="mt-6 rounded-xl border bg-primary/5 p-5">
@@ -306,24 +375,18 @@ export default function SfdaToolDemo({
               Want this on your full portfolio?
             </h4>
             <p className="text-xs text-muted-foreground leading-relaxed mb-4">
-              The free preview runs the simplified pipeline on one document.
-              The full version integrates the SFDA Module 1.3 template + GCC
-              Guidance v3.1, returns editable {outputFormat}, and runs across
-              your portfolio with QMS integration. Walk through your output
-              with our team and license for your team.
+              The free preview runs the SFDA Module 1.3 + GCC Guidance v3.1
+              pipeline on a single submission. The licensed version runs across
+              your portfolio with QMS integration and full audit trail. Walk
+              through your output with our team and license for your team.
             </p>
-            <div className="flex flex-col sm:flex-row gap-2">
-              <Button size="default" asChild>
-                <a href={BOOK_DEMO_URL} target="_blank" rel="noopener noreferrer">
-                  <CalendarClock className="size-4 mr-2" />
-                  Book a 30-min walkthrough
-                  <ArrowRight className="size-4 ml-2" />
-                </a>
-              </Button>
-              <Button size="default" variant="outline" onClick={handleResetForRetry}>
-                Done
-              </Button>
-            </div>
+            <Button size="default" asChild>
+              <a href={BOOK_DEMO_URL} target="_blank" rel="noopener noreferrer">
+                <CalendarClock className="size-4 mr-2" />
+                Book a 30-min walkthrough
+                <ArrowRight className="size-4 ml-2" />
+              </a>
+            </Button>
             <p className="mt-3 text-[11px] text-muted-foreground">
               {Math.max(0, freeUses - usageCount)} free run
               {freeUses - usageCount === 1 ? "" : "s"} remaining
@@ -465,7 +528,7 @@ export default function SfdaToolDemo({
             {isProcessing ? (
               <span className="inline-flex items-center gap-1.5 text-primary">
                 <Loader2 className="size-3.5 animate-spin" />
-                Running on your documents — typically 30–90 seconds…
+                Running on your documents — typically 30–120 seconds…
               </span>
             ) : allRequiredUploaded ? (
               <span className="inline-flex items-center gap-1.5 text-primary">
@@ -501,7 +564,7 @@ export default function SfdaToolDemo({
 
         <p className="mt-3 text-[11px] text-muted-foreground text-center">
           Files processed in your workspace, not stored externally · One free
-          run per tool
+          run per tool · Output downloadable as DOCX
         </p>
       </CardContent>
     </Card>

--- a/client/src/lib/sfda/markdown-to-docx.ts
+++ b/client/src/lib/sfda/markdown-to-docx.ts
@@ -1,0 +1,170 @@
+/**
+ * Convert the SFDA tool markdown output into a DOCX Blob for download.
+ *
+ * The LLM produces a predictable markdown subset (headings, **bold**,
+ * *italic*, `- ` bullets, `1. ` numbered, `---` rules, paragraphs). Tables
+ * and code blocks are not used by the prompts, so we don't attempt to render
+ * them faithfully — they fall back to plain paragraphs.
+ *
+ * Arabic documents use `bidirectional: true` and right-aligned text via the
+ * `rtl` option on the document.
+ */
+
+import {
+  AlignmentType,
+  Document,
+  HeadingLevel,
+  LevelFormat,
+  Packer,
+  Paragraph,
+  TextRun,
+} from "docx";
+
+interface MdToDocxOptions {
+  title?: string;
+  rtl?: boolean;
+}
+
+function parseInlineRuns(text: string, rtl: boolean): TextRun[] {
+  // Strip leading/trailing whitespace once, splitting **bold** and *italic*.
+  const parts: TextRun[] = [];
+  // Capture **bold** | *italic* | text. Order matters — bold first.
+  const re = /(\*\*[^*]+\*\*|\*[^*]+\*|[^*]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const segment = match[0];
+    if (segment.startsWith("**") && segment.endsWith("**")) {
+      parts.push(new TextRun({ text: segment.slice(2, -2), bold: true, rightToLeft: rtl }));
+    } else if (segment.startsWith("*") && segment.endsWith("*")) {
+      parts.push(new TextRun({ text: segment.slice(1, -1), italics: true, rightToLeft: rtl }));
+    } else {
+      parts.push(new TextRun({ text: segment, rightToLeft: rtl }));
+    }
+  }
+  if (parts.length === 0) {
+    parts.push(new TextRun({ text, rightToLeft: rtl }));
+  }
+  return parts;
+}
+
+function paragraphFor(line: string, rtl: boolean): Paragraph {
+  const align = rtl ? AlignmentType.RIGHT : AlignmentType.LEFT;
+
+  if (line.startsWith("# ")) {
+    return new Paragraph({
+      heading: HeadingLevel.HEADING_1,
+      bidirectional: rtl,
+      alignment: align,
+      children: parseInlineRuns(line.slice(2), rtl),
+    });
+  }
+  if (line.startsWith("## ")) {
+    return new Paragraph({
+      heading: HeadingLevel.HEADING_2,
+      bidirectional: rtl,
+      alignment: align,
+      children: parseInlineRuns(line.slice(3), rtl),
+    });
+  }
+  if (line.startsWith("### ")) {
+    return new Paragraph({
+      heading: HeadingLevel.HEADING_3,
+      bidirectional: rtl,
+      alignment: align,
+      children: parseInlineRuns(line.slice(4), rtl),
+    });
+  }
+  if (line.startsWith("- ") || line.startsWith("* ")) {
+    return new Paragraph({
+      bullet: { level: 0 },
+      bidirectional: rtl,
+      alignment: align,
+      children: parseInlineRuns(line.slice(2), rtl),
+    });
+  }
+  const numberedMatch = line.match(/^(\d+)\.\s+(.*)$/);
+  if (numberedMatch) {
+    return new Paragraph({
+      numbering: { reference: "sfda-numbering", level: 0 },
+      bidirectional: rtl,
+      alignment: align,
+      children: parseInlineRuns(numberedMatch[2], rtl),
+    });
+  }
+  if (line.trim() === "---" || line.trim() === "***") {
+    return new Paragraph({
+      alignment: AlignmentType.CENTER,
+      children: [new TextRun({ text: "—".repeat(20) })],
+    });
+  }
+  return new Paragraph({
+    bidirectional: rtl,
+    alignment: align,
+    children: parseInlineRuns(line, rtl),
+  });
+}
+
+export async function markdownToDocxBlob(
+  markdown: string,
+  opts: MdToDocxOptions = {}
+): Promise<Blob> {
+  const rtl = !!opts.rtl;
+  const lines = markdown.split("\n");
+  const children: Paragraph[] = [];
+
+  if (opts.title) {
+    children.push(
+      new Paragraph({
+        heading: HeadingLevel.TITLE,
+        bidirectional: rtl,
+        alignment: rtl ? AlignmentType.RIGHT : AlignmentType.LEFT,
+        children: parseInlineRuns(opts.title, rtl),
+      })
+    );
+  }
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      children.push(new Paragraph({}));
+      continue;
+    }
+    children.push(paragraphFor(line, rtl));
+  }
+
+  const doc = new Document({
+    numbering: {
+      config: [
+        {
+          reference: "sfda-numbering",
+          levels: [
+            {
+              level: 0,
+              format: LevelFormat.DECIMAL,
+              text: "%1.",
+              alignment: rtl ? AlignmentType.RIGHT : AlignmentType.LEFT,
+            },
+          ],
+        },
+      ],
+    },
+    sections: [
+      {
+        properties: {},
+        children,
+      },
+    ],
+  });
+
+  return Packer.toBlob(doc);
+}
+
+export function triggerDocxDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".docx") ? filename : `${filename}.docx`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/client/src/lib/sfda/tools.ts
+++ b/client/src/lib/sfda/tools.ts
@@ -422,7 +422,7 @@ export const SFDA_TOOLS: SfdaTool[] = [
     ],
     output: {
       label: "Section-by-section gap report with severity ranking",
-      format: "PDF + on-screen viewer",
+      format: "DOCX",
     },
     features: [
       {

--- a/server/services/sfda/dossier-gap-analysis.ts
+++ b/server/services/sfda/dossier-gap-analysis.ts
@@ -286,7 +286,13 @@ ${storageConditionsFinal}`;
   });
 
   return {
-    markdown: report,
+    documents: [
+      {
+        id: "gap_analysis_report",
+        title: "SFDA Dossier Gap Analysis Report",
+        markdown: report,
+      },
+    ],
     model:
       process.env.OPENROUTER_SFDA_MODEL ||
       process.env.OPENROUTER_MODEL ||

--- a/server/services/sfda/spc-pil-arabic-translator.ts
+++ b/server/services/sfda/spc-pil-arabic-translator.ts
@@ -234,18 +234,21 @@ OUTPUT INSTRUCTIONS: Start your response directly with the SPC title heading in 
     maxTokens: 16000,
   });
 
-  const markdown = `# نشرة الدواء (Arabic PIL)
-
-${pilArabic}
-
----
-
-# ملخص خصائص المنتج (Arabic SmPC)
-
-${spcArabic}`;
-
   return {
-    markdown,
+    documents: [
+      {
+        id: "pil_arabic",
+        title: "نشرة معلومات المريض (Arabic PIL)",
+        markdown: pilArabic,
+        rtl: true,
+      },
+      {
+        id: "spc_arabic",
+        title: "ملخص خصائص المنتج (Arabic SmPC)",
+        markdown: spcArabic,
+        rtl: true,
+      },
+    ],
     model:
       process.env.OPENROUTER_SFDA_MODEL ||
       process.env.OPENROUTER_MODEL ||

--- a/server/services/sfda/spc-pil-generator.ts
+++ b/server/services/sfda/spc-pil-generator.ts
@@ -322,24 +322,24 @@ Return all extracted information clearly and completely. Do not omit any data po
     maxTokens: 16000,
   });
 
-  const markdown = `# Patient Information Leaflet (English)
-
-${pilEnglish}
-
----
-
-# Summary of Product Characteristics (English)
-
-${spcEnglish}
-
----
-
-## Extracted Drug Data
-
-${extractedData}`;
-
   return {
-    markdown,
+    documents: [
+      {
+        id: "pil_english",
+        title: "Patient Information Leaflet (English)",
+        markdown: pilEnglish,
+      },
+      {
+        id: "spc_english",
+        title: "Summary of Product Characteristics (English)",
+        markdown: spcEnglish,
+      },
+      {
+        id: "extracted_data",
+        title: "Extracted Drug Data",
+        markdown: extractedData,
+      },
+    ],
     model:
       process.env.OPENROUTER_SFDA_MODEL ||
       process.env.OPENROUTER_MODEL ||

--- a/server/services/sfda/types.ts
+++ b/server/services/sfda/types.ts
@@ -9,8 +9,20 @@ export interface SfdaUploadedFile {
   base64: string;
 }
 
-export interface SfdaToolResult {
+/** A single output document — each one renders in its own card client-side. */
+export interface SfdaDocument {
+  /** Stable ID for keying / download filenames. */
+  id: string;
+  /** Display title shown above the document content. */
+  title: string;
+  /** Markdown content of the document. */
   markdown: string;
+  /** Set true for Arabic documents so the DOCX export uses RTL formatting. */
+  rtl?: boolean;
+}
+
+export interface SfdaToolResult {
+  documents: SfdaDocument[];
   model: string;
 }
 


### PR DESCRIPTION
UX feedback: rendering all output documents in a single scrollable markdown block is hard to read — separate them into independent cards with their own copy/download controls. Also: download should produce a real DOCX, not a markdown file.

## Server

`SfdaToolResult.documents: SfdaDocument[]` replaces the single `markdown` field. Each tool now returns multiple documents:

| Tool | Documents |
|---|---|
| `spc-pil-generator` | English PIL, English SmPC, Extracted Drug Data |
| `spc-pil-arabic-translator` | Arabic PIL (rtl), Arabic SmPC (rtl) |
| `dossier-gap-analysis` | Single gap analysis report |

## Client

- New `DocumentCard` component renders each document with its own header (Copy + Download .docx buttons) and a scrollable markdown preview.
- Arabic documents render with `dir="rtl"` and right-aligned DOCX paragraphs.
- New `client/src/lib/sfda/markdown-to-docx.ts` converts the LLM's markdown subset (#/##/### headings, **bold**, *italic*, bullets, numbered lists, --- rules) to a proper DOCX Blob via the `docx` package already in deps.
- Done-state header shows document count; cards stack vertically.

## After merge

Hard-refresh `bytebeam.co/sfda/spc-pil-generator` after deploy. The output should split into 3 separate cards (English PIL / English SmPC / Extracted Drug Data) and the **.docx** button should produce a real Word file.