### PR TITLE
SmPC+PIL Generator: drop extracted-data doc, lay docs side-by-side

### DIFF
--- a/client/src/components/sfda/SfdaToolDemo.tsx
+++ b/client/src/components/sfda/SfdaToolDemo.tsx
@@ -363,7 +363,12 @@ export default function SfdaToolDemo({
             </Button>
           </div>
 
-          <div className="space-y-4">
+          <div
+            className={cn(
+              "grid gap-4",
+              documents.length > 1 ? "grid-cols-1 lg:grid-cols-2" : "grid-cols-1"
+            )}
+          >
             {documents.map((doc, i) => (
               <DocumentCard key={doc.id} doc={doc} toolSlug={toolSlug} index={i} />
             ))}

--- a/server/services/sfda/spc-pil-generator.ts
+++ b/server/services/sfda/spc-pil-generator.ts
@@ -334,11 +334,6 @@ Return all extracted information clearly and completely. Do not omit any data po
         title: "Summary of Product Characteristics (English)",
         markdown: spcEnglish,
       },
-      {
-        id: "extracted_data",
-        title: "Extracted Drug Data",
-        markdown: extractedData,
-      },
     ],
     model:
       process.env.OPENROUTER_SFDA_MODEL ||


### PR DESCRIPTION
Two small UX changes:

1. **`spc-pil-generator` now returns 2 docs instead of 3** — drop the "Extracted Drug Data" output. That was an intermediate prompt artefact, not a deliverable.
2. **DocumentCards lay out side-by-side** when there are 2 documents — `grid-cols-1 lg:grid-cols-2`. Single-doc tools (gap analysis) stay full-width.

Affects:
- Generator: PIL + SmPC side-by-side (2 cards instead of 3 stacked)
- Arabic Translator: PIL Arabic + SmPC Arabic side-by-side
- Gap Analysis: unchanged (still 1 full-width report)