### PR TITLE
Output state: break out to wide layout for multi-doc results

### DIFF
--- a/client/src/components/sfda/SfdaToolDemo.tsx
+++ b/client/src/components/sfda/SfdaToolDemo.tsx
@@ -354,6 +354,7 @@ export default function SfdaToolDemo({
             "relative left-1/2 -translate-x-1/2 w-screen max-w-7xl px-4 sm:px-6 lg:px-8"
         )}
       >
+      <Card>
         <CardContent className="p-6 sm:p-8">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
             <div className="flex items-center gap-3">

--- a/client/src/components/sfda/SfdaToolDemo.tsx
+++ b/client/src/components/sfda/SfdaToolDemo.tsx
@@ -343,8 +343,17 @@ export default function SfdaToolDemo({
 
   // ─── Done — render each document in its own card ───
   if (state === "done") {
+    // For multi-document outputs, escape the parent's max-w-3xl so cards have
+    // room to breathe side-by-side. CSS trick: w-screen + max-w-7xl + center
+    // via left:50% / -translate-x-1/2 breaks free of any ancestor max-width.
+    const isWide = documents.length > 1;
     return (
-      <Card>
+      <div
+        className={cn(
+          isWide &&
+            "relative left-1/2 -translate-x-1/2 w-screen max-w-7xl px-4 sm:px-6 lg:px-8"
+        )}
+      >
         <CardContent className="p-6 sm:p-8">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
             <div className="flex items-center gap-3">
@@ -399,6 +408,7 @@ export default function SfdaToolDemo({
           </div>
         </CardContent>
       </Card>
+      </div>
     );
   }
 


### PR DESCRIPTION
The done-state output was constrained by the page's max-w-3xl form wrapper, leaving huge empty space on either side when two document cards rendered side-by-side.

Fix: wrap the multi-document output in a CSS escape container (w-screen + max-w-7xl + left-1/2 + -translate-x-1/2) that breaks out of the ancestor's narrow constraint and uses up to 1280px viewport-centered.

- Generator + Arabic Translator (2 docs): wide breakout, side-by-side cards have plenty of room
- Gap Analysis (1 doc): unchanged, keeps the narrower form-aligned width
- Form / processing / error states: unchanged