### PR TITLE
Add 5-blog SFDA/pharma RA cluster + discovery-call CTA (framework-aligned)

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -432,7 +432,42 @@
 
   <url>
     <loc>https://bytebeam.co/blog/sfda-drug-registration-guide-saudi-arabia</loc>
-    <lastmod>2026-01-16</lastmod>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/sfda-pharmacovigilance-qppv-requirements</loc>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/sfda-variations-type-ia-ib-ii-decision-guide</loc>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/sfda-ectd-submission-module-structure</loc>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/sfda-drug-master-file-letter-of-access</loc>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/sfda-impurity-profile-ich-q3a-q3b-q3d</loc>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -91,6 +91,11 @@ const BlogIndex = lazy(() => import("@/pages/blog/index"));
 const AutomationPlatformComparisonBlog = lazy(() => import("@/pages/blog/automation-platform-comparison-2026"));
 const UAEFoodLabelingBlog = lazy(() => import("@/pages/blog/uae-food-labeling-requirements-2026"));
 const SFDADrugRegistrationBlog = lazy(() => import("@/pages/blog/sfda-drug-registration-guide-saudi-arabia"));
+const SFDAPharmacovigilanceQppvBlog = lazy(() => import("@/pages/blog/sfda-pharmacovigilance-qppv-requirements"));
+const SFDAVariationsBlog = lazy(() => import("@/pages/blog/sfda-variations-type-ia-ib-ii-decision-guide"));
+const SFDAEctdBlog = lazy(() => import("@/pages/blog/sfda-ectd-submission-module-structure"));
+const SFDADmfBlog = lazy(() => import("@/pages/blog/sfda-drug-master-file-letter-of-access"));
+const SFDAImpurityProfileBlog = lazy(() => import("@/pages/blog/sfda-impurity-profile-ich-q3a-q3b-q3d"));
 const MontajiPortalBlog = lazy(() => import("@/pages/blog/dubai-municipality-montaji-food-registration"));
 const GCCDocumentComplianceBlog = lazy(() => import("@/pages/blog/gcc-document-compliance-automation-2026"));
 const NoCodeDocumentAutomationBlog = lazy(() => import("@/pages/blog/no-code-document-automation-regulatory-teams-2026"));
@@ -185,6 +190,11 @@ function Router() {
         <Route path="/blog/automation-platform-comparison-2026" component={AutomationPlatformComparisonBlog} />
         <Route path="/blog/uae-food-labeling-requirements-2026" component={UAEFoodLabelingBlog} />
         <Route path="/blog/sfda-drug-registration-guide-saudi-arabia" component={SFDADrugRegistrationBlog} />
+        <Route path="/blog/sfda-pharmacovigilance-qppv-requirements" component={SFDAPharmacovigilanceQppvBlog} />
+        <Route path="/blog/sfda-variations-type-ia-ib-ii-decision-guide" component={SFDAVariationsBlog} />
+        <Route path="/blog/sfda-ectd-submission-module-structure" component={SFDAEctdBlog} />
+        <Route path="/blog/sfda-drug-master-file-letter-of-access" component={SFDADmfBlog} />
+        <Route path="/blog/sfda-impurity-profile-ich-q3a-q3b-q3d" component={SFDAImpurityProfileBlog} />
         <Route path="/blog/dubai-municipality-montaji-food-registration" component={MontajiPortalBlog} />
         <Route path="/blog/gcc-document-compliance-automation-2026" component={GCCDocumentComplianceBlog} />
         <Route path="/blog/no-code-document-automation-regulatory-teams-2026" component={NoCodeDocumentAutomationBlog} />

--- a/client/src/components/blog/BlogDiscoveryCallCta.tsx
+++ b/client/src/components/blog/BlogDiscoveryCallCta.tsx
@@ -1,0 +1,166 @@
+/**
+ * Process-specific discovery-call CTA for pharma RA blog posts that don't
+ * map to one of the 3 existing SFDA tools. Designed for in-house RA / PV
+ * teams who own the process — not consultancies.
+ *
+ * The CTA framing is intentional and aligned with the platform pitch:
+ *   "Walk us through your [process]. We'll show you what we'd automate."
+ *
+ * That framing:
+ *   - Speaks to in-house RA teams (they own the process)
+ *   - Promises a concrete value (custom automation scope)
+ *   - Doesn't oversell — no upfront commitment beyond a 30-min call
+ *   - Self-qualifies: consultancies skip this, in-house teams engage
+ *
+ * Each blog passes a `topic` like "PV", "variations", "DMF" so the
+ * headline + framing match. Variants for A/B testing live in the
+ * variant prop — change them in source for now; can be wired to an
+ * analytics flag later.
+ */
+
+import { ArrowRight, CalendarClock, CheckCircle2, Sparkles } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Link } from "wouter";
+import { SFDA_BOOKING_URL } from "@/lib/sfda/tools";
+
+interface BlogDiscoveryCallCtaProps {
+  /** Topic noun used to specialise the framing — e.g. "PV", "variations", "DMF". */
+  topic: string;
+  /** Optional eyebrow override (defaults to "Bytebeam · Discovery call"). */
+  eyebrow?: string;
+  /** Headline override. Falls back to a process-scoping framing built from `topic`. */
+  headline?: string;
+  /** Body copy override. Falls back to the standard "walk us through your process" line. */
+  body?: string;
+  /** "What to expect" bullets shown beneath the body. Three short lines is ideal. */
+  expectations?: string[];
+  /** CTA button label. Defaults to "Book a 30-min scoping call". */
+  ctaLabel?: string;
+  /**
+   * "Proof of pattern" line linking to /sfda hub — anchors the offer in
+   * the 3 existing tools so readers know we ship working agents, not
+   * vapourware.
+   */
+  showProofOfPattern?: boolean;
+  /** Visual variant. "inline" is a smaller mid-article block; "panel" is the bigger end-of-article version. */
+  variant?: "inline" | "panel";
+}
+
+const DEFAULT_EXPECTATIONS = [
+  "You walk us through how your team handles the work today",
+  "We map the document touchpoints we'd automate first",
+  "You leave with a written scoping summary — no commitment",
+];
+
+export default function BlogDiscoveryCallCta({
+  topic,
+  eyebrow = "Bytebeam · Discovery call",
+  headline,
+  body,
+  expectations = DEFAULT_EXPECTATIONS,
+  ctaLabel = "Book a 30-min scoping call",
+  showProofOfPattern = true,
+  variant = "panel",
+}: BlogDiscoveryCallCtaProps) {
+  const resolvedHeadline =
+    headline ?? `Scope ${topic} automation with your team's process, not a generic template`;
+  const resolvedBody =
+    body ??
+    `Walk us through how your team currently handles ${topic} work. In 30 minutes we'll map the document touchpoints we'd automate first, and share a written scoping summary you can take back to your QPPV / Head of RA. No commitment, no template demos — your process leads.`;
+
+  if (variant === "inline") {
+    return (
+      <aside className="not-prose my-10" aria-label={`Book a ${topic} scoping call`}>
+        <Card className="border-2 border-primary/20 bg-gradient-to-br from-primary/5 via-background to-background">
+          <CardContent className="p-5 sm:p-6">
+            <div className="flex flex-col sm:flex-row gap-5 items-start">
+              <div className="flex size-11 items-center justify-center rounded-xl bg-primary/15 text-primary shrink-0">
+                <CalendarClock className="size-5" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <Badge variant="secondary" className="gap-1.5 mb-2">
+                  <Sparkles className="size-3 text-primary" />
+                  {eyebrow}
+                </Badge>
+                <h3 className="text-base sm:text-lg font-semibold leading-snug mb-1.5">
+                  {resolvedHeadline}
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed mb-4">
+                  {resolvedBody}
+                </p>
+                <Button asChild>
+                  <a
+                    href={SFDA_BOOKING_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {ctaLabel}
+                    <ArrowRight className="size-4 ml-2" />
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="not-prose my-12" aria-label={`Book a ${topic} scoping call`}>
+      <Card className="border-2 border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-background overflow-hidden">
+        <CardContent className="p-6 sm:p-8 lg:p-10">
+          <div className="grid gap-8 lg:grid-cols-[1fr_auto] items-start">
+            <div className="flex-1 min-w-0">
+              <Badge variant="secondary" className="gap-1.5 mb-4">
+                <Sparkles className="size-3 text-primary" />
+                {eyebrow}
+              </Badge>
+              <h3 className="text-xl sm:text-2xl font-bold leading-snug mb-3">
+                {resolvedHeadline}
+              </h3>
+              <p className="text-sm sm:text-base text-muted-foreground leading-relaxed mb-5">
+                {resolvedBody}
+              </p>
+              {expectations.length > 0 && (
+                <ul className="space-y-2.5 mb-6">
+                  {expectations.map((line, i) => (
+                    <li key={i} className="flex gap-2.5 text-sm text-foreground/85">
+                      <CheckCircle2 className="size-4 text-primary shrink-0 mt-0.5" />
+                      <span className="leading-relaxed">{line}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div className="flex flex-col sm:flex-row gap-3">
+                <Button asChild size="lg">
+                  <a
+                    href={SFDA_BOOKING_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <CalendarClock className="size-4 mr-2" />
+                    {ctaLabel}
+                    <ArrowRight className="size-4 ml-2" />
+                  </a>
+                </Button>
+                {showProofOfPattern && (
+                  <Button variant="outline" size="lg" asChild>
+                    <Link href="/sfda">See what we've already shipped</Link>
+                  </Button>
+                )}
+              </div>
+              {showProofOfPattern && (
+                <p className="mt-4 text-xs text-muted-foreground">
+                  Proof of pattern — three SFDA Module 1.3 agents already in production: SmPC + PIL Generator, Arabic Translator, Dossier Gap Analysis.
+                </p>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </aside>
+  );
+}

--- a/client/src/lib/blog/posts.ts
+++ b/client/src/lib/blog/posts.ts
@@ -39,6 +39,71 @@ export interface BlogPostMeta {
 
 export const BLOG_POSTS: BlogPostMeta[] = [
   {
+    slug: "sfda-pharmacovigilance-qppv-requirements",
+    title:
+      "SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026",
+    shortTitle: "SFDA Pharmacovigilance & QPPV Guide",
+    description:
+      "What in-house RA/PV teams need to know about SFDA pharmacovigilance: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, Saudi-national rules, and where automation actually helps.",
+    category: "Regulatory",
+    industry: "Pharma",
+    readTime: "14 min",
+    date: "2026-05-07",
+    updated: "2026-05-07",
+  },
+  {
+    slug: "sfda-variations-type-ia-ib-ii-decision-guide",
+    title:
+      "SFDA Variations Decision Guide: Type IA, IB, II — A Practical Reference for In-House RA Teams",
+    shortTitle: "SFDA Variations Decision Guide",
+    description:
+      "How SFDA classifies post-approval variations under Guidelines v6.3/v6.4, when to use Type IA / IA(IN) / IB / II, the documentation each requires, and where the work is automatable.",
+    category: "Regulatory",
+    industry: "Pharma",
+    readTime: "14 min",
+    date: "2026-05-07",
+    updated: "2026-05-07",
+  },
+  {
+    slug: "sfda-ectd-submission-module-structure",
+    title:
+      "SFDA eCTD Submission Format: Module 1 Regional Requirements & Common RFIs in 2026",
+    shortTitle: "SFDA eCTD Submission Format",
+    description:
+      "How SFDA submissions actually work in eCTD: the GCC Module 1 specification, what each module contains, what triggers RFIs, and where in-house teams should focus automation.",
+    category: "Regulatory",
+    industry: "Pharma",
+    readTime: "14 min",
+    date: "2026-05-07",
+    updated: "2026-05-07",
+  },
+  {
+    slug: "sfda-drug-master-file-letter-of-access",
+    title:
+      "SFDA Drug Master File (DMF) and Letter of Access: A Practical Guide for API Manufacturers and MAHs",
+    shortTitle: "SFDA DMF & Letter of Access Guide",
+    description:
+      "How DMFs are submitted to SFDA, how the Letter of Access works, what the restricted and open parts must contain, and where API manufacturers most often lose review time.",
+    category: "Regulatory",
+    industry: "Pharma",
+    readTime: "13 min",
+    date: "2026-05-07",
+    updated: "2026-05-07",
+  },
+  {
+    slug: "sfda-impurity-profile-ich-q3a-q3b-q3d",
+    title:
+      "Impurity Profile for SFDA Drug Submissions: ICH Q3A, Q3B, Q3D, and M7 in Practice",
+    shortTitle: "Impurity Profile Guide (ICH Q3 / M7)",
+    description:
+      "How to build a defensible impurity profile for SFDA submissions. Reporting, identification, and qualification thresholds under ICH Q3A/B; elemental impurities under Q3D; mutagenic impurities under M7.",
+    category: "Regulatory",
+    industry: "Pharma",
+    readTime: "14 min",
+    date: "2026-05-07",
+    updated: "2026-05-07",
+  },
+  {
     slug: "sfda-drug-registration-guide-saudi-arabia",
     title: "SFDA Drug Registration Guide Saudi Arabia: Complete 2026 Process",
     shortTitle: "SFDA Drug Registration Guide",
@@ -46,8 +111,9 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "Navigate SFDA drug registration in Saudi Arabia. Complete guide covering CTD requirements, GMP certification, pricing approval, and timeline for 2026.",
     category: "Regulatory",
     industry: "Pharma",
-    readTime: "14 min",
+    readTime: "18 min",
     date: "2026-01-16",
+    updated: "2026-05-07",
   },
   {
     slug: "no-code-document-automation-regulatory-teams-2026",

--- a/client/src/lib/blog/posts.ts
+++ b/client/src/lib/blog/posts.ts
@@ -44,7 +44,7 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026",
     shortTitle: "SFDA Pharmacovigilance & QPPV Guide",
     description:
-      "What in-house RA/PV teams need to know about SFDA pharmacovigilance: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, Saudi-national rules, and where automation actually helps.",
+      "SFDA pharmacovigilance for in-house RA/PV teams: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, and where automation actually helps in 2026.",
     category: "Regulatory",
     industry: "Pharma",
     readTime: "14 min",
@@ -57,7 +57,7 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "SFDA Variations Decision Guide: Type IA, IB, II — A Practical Reference for In-House RA Teams",
     shortTitle: "SFDA Variations Decision Guide",
     description:
-      "How SFDA classifies post-approval variations under Guidelines v6.3/v6.4, when to use Type IA / IA(IN) / IB / II, the documentation each requires, and where the work is automatable.",
+      "How SFDA classifies post-approval variations under Guidelines v6.3, when to use Type IA / IA(IN) / IB / II, and where the work is automatable.",
     category: "Regulatory",
     industry: "Pharma",
     readTime: "14 min",
@@ -70,7 +70,7 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "SFDA eCTD Submission Format: Module 1 Regional Requirements & Common RFIs in 2026",
     shortTitle: "SFDA eCTD Submission Format",
     description:
-      "How SFDA submissions actually work in eCTD: the GCC Module 1 specification, what each module contains, what triggers RFIs, and where in-house teams should focus automation.",
+      "How SFDA submissions work in eCTD: GCC Module 1 specification, module content, what triggers RFIs, and where in-house teams should focus automation.",
     category: "Regulatory",
     industry: "Pharma",
     readTime: "14 min",
@@ -83,7 +83,7 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "SFDA Drug Master File (DMF) and Letter of Access: A Practical Guide for API Manufacturers and MAHs",
     shortTitle: "SFDA DMF & Letter of Access Guide",
     description:
-      "How DMFs are submitted to SFDA, how the Letter of Access works, what the restricted and open parts must contain, and where API manufacturers most often lose review time.",
+      "How DMFs are submitted to SFDA, how the Letter of Access works, what the open and restricted parts contain, and where API manufacturers lose review time.",
     category: "Regulatory",
     industry: "Pharma",
     readTime: "13 min",
@@ -96,7 +96,7 @@ export const BLOG_POSTS: BlogPostMeta[] = [
       "Impurity Profile for SFDA Drug Submissions: ICH Q3A, Q3B, Q3D, and M7 in Practice",
     shortTitle: "Impurity Profile Guide (ICH Q3 / M7)",
     description:
-      "How to build a defensible impurity profile for SFDA submissions. Reporting, identification, and qualification thresholds under ICH Q3A/B; elemental impurities under Q3D; mutagenic impurities under M7.",
+      "Build a defensible impurity profile for SFDA submissions: ICH Q3A/B thresholds, Q3D elemental impurities, and M7 mutagenic-impurity assessment.",
     category: "Regulatory",
     industry: "Pharma",
     readTime: "14 min",

--- a/client/src/lib/sfda/tools.ts
+++ b/client/src/lib/sfda/tools.ts
@@ -72,9 +72,20 @@ export interface SfdaTool {
   resources?: SfdaToolResource[];
 }
 
-/** Where every "Book a demo" CTA points. Sales-led license conversion. */
+/**
+ * Where every "Book a demo" / "Book a discovery call" CTA points across
+ * the SFDA/pharma surface. Replace with the production Google Calendar
+ * appointment-scheduling URL when ready — this constant is the single
+ * source of truth so swapping is one-line.
+ *
+ * Sales-led license conversion: the booking page collects qualifying
+ * info via Google Calendar's built-in form (name, email, note).
+ */
 export const BOOK_DEMO_URL =
-  "https://calendly.com/talal-bytebeam/sfda-discovery";
+  "https://calendar.app.google/sfda-discovery-bytebeam";
+
+/** Alias for clarity in blog content where we frame as a "discovery call". */
+export const SFDA_BOOKING_URL = BOOK_DEMO_URL;
 
 /** Default number of free runs per tool before the demo gate kicks in. */
 export const DEFAULT_FREE_USES = 1;

--- a/client/src/lib/sfda/tools.ts
+++ b/client/src/lib/sfda/tools.ts
@@ -252,14 +252,19 @@ export const SFDA_TOOLS: SfdaTool[] = [
     ],
     resources: [
       {
-        slug: "sfda-drug-registration-guide-saudi-arabia",
-        title: "SFDA Drug Registration Guide Saudi Arabia",
-        hook: "Where SmPC + PIL fits in the full Module 1.3 submission lifecycle",
+        slug: "sfda-ectd-submission-module-structure",
+        title: "SFDA eCTD Submission Format & Module Structure",
+        hook: "Where Module 1.3 SmPC + PIL fits in the full eCTD pack",
       },
       {
-        slug: "no-code-document-automation-regulatory-teams-2026",
-        title: "No-Code Document Automation for Regulatory Teams",
-        hook: "Why purpose-built RA agents beat generic workflow builders",
+        slug: "sfda-drug-registration-guide-saudi-arabia",
+        title: "SFDA Drug Registration Guide Saudi Arabia",
+        hook: "Full submission lifecycle from CTD prep to pricing approval",
+      },
+      {
+        slug: "sfda-variations-type-ia-ib-ii-decision-guide",
+        title: "SFDA Variations Type IA / IB / II Decision Guide",
+        hook: "How variations propagate to Module 1.3 labelling — and back",
       },
     ],
   },
@@ -405,9 +410,14 @@ export const SFDA_TOOLS: SfdaTool[] = [
     ],
     resources: [
       {
+        slug: "sfda-ectd-submission-module-structure",
+        title: "SFDA eCTD Submission Format & Module Structure",
+        hook: "Where Arabic PIL sits in the GCC Module 1 specification",
+      },
+      {
         slug: "arabic-ocr-challenges-solutions-2026",
         title: "Arabic OCR in 2026: Why It's Still Hard and What Actually Works",
-        hook: "Why generic translation fails for SFDA labelling — and what regulator-recognised Arabic looks like",
+        hook: "Why generic translation fails for SFDA labelling",
       },
       {
         slug: "sfda-drug-registration-guide-saudi-arabia",
@@ -574,14 +584,19 @@ export const SFDA_TOOLS: SfdaTool[] = [
     ],
     resources: [
       {
-        slug: "sfda-drug-registration-guide-saudi-arabia",
-        title: "SFDA Drug Registration Guide Saudi Arabia",
-        hook: "The full submission process — and where labelling RFIs typically come from",
+        slug: "sfda-ectd-submission-module-structure",
+        title: "SFDA eCTD Submission Format & Module Structure",
+        hook: "Module 1.3 RFI patterns — and where to focus pre-submission QC",
       },
       {
-        slug: "no-code-document-automation-regulatory-teams-2026",
-        title: "No-Code Document Automation for Regulatory Teams",
-        hook: "How RA teams stand up pre-submission QC without IT",
+        slug: "sfda-pharmacovigilance-qppv-requirements",
+        title: "SFDA Pharmacovigilance & QPPV Requirements",
+        hook: "Gap analysis applies to PSUR / RMP / PSSF too — same pattern, different documents",
+      },
+      {
+        slug: "sfda-variations-type-ia-ib-ii-decision-guide",
+        title: "SFDA Variations Type IA / IB / II Decision Guide",
+        hook: "Pre-submission QC for variation packs — catch labelling drift before SFDA does",
       },
     ],
   },

--- a/client/src/pages/blog/sfda-drug-master-file-letter-of-access.tsx
+++ b/client/src/pages/blog/sfda-drug-master-file-letter-of-access.tsx
@@ -15,7 +15,7 @@ const structuredData = [
     headline:
       "SFDA Drug Master File (DMF) and Letter of Access: A Practical Guide for API Manufacturers and MAHs",
     description:
-      "How DMFs are submitted to SFDA, how the Letter of Access works, what the restricted and open parts must contain, and where API manufacturers most often lose review time.",
+      "How DMFs are submitted to SFDA, how the Letter of Access works, what the open and restricted parts contain, and where API manufacturers lose review time.",
     image: "https://bytebeam.co/images/blog/sfda-drug-master-file.jpg",
     author: {
       "@type": "Person",
@@ -69,7 +69,7 @@ export default function SfdaDmfBlog() {
   return (
     <BlogLayout
       title="SFDA Drug Master File (DMF) and Letter of Access: A Practical Guide for API Manufacturers and MAHs"
-      description="How DMFs are submitted to SFDA, how the Letter of Access works, what the restricted and open parts must contain, and where API manufacturers most often lose review time."
+      description="How DMFs are submitted to SFDA, how the Letter of Access works, what the open and restricted parts contain, and where API manufacturers lose review time."
       keywords="SFDA DMF, SFDA Drug Master File, Letter of Access SFDA, Active Substance Master File ASMF, API regulatory Saudi Arabia, DMF submission Saudi, restricted part DMF, open part DMF"
       canonical="https://bytebeam.co/blog/sfda-drug-master-file-letter-of-access"
       structuredData={structuredData}
@@ -291,7 +291,7 @@ export default function SfdaDmfBlog() {
       <h2>ByteBeam and SFDA DMF / Letter of Access automation</h2>
 
       <p>
-        ByteBeam ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not generic copilots. Three are already in production for <strong>Module 1.3 labelling</strong>:
+        ByteBeam's <Link href="/sfda">SFDA labelling toolkit</Link> ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not generic copilots. Three are already in production for <strong>Module 1.3 labelling</strong>:
       </p>
 
       <ul>

--- a/client/src/pages/blog/sfda-drug-master-file-letter-of-access.tsx
+++ b/client/src/pages/blog/sfda-drug-master-file-letter-of-access.tsx
@@ -1,0 +1,461 @@
+import { Link } from "wouter";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+import BlogRelatedTools from "@/components/blog/BlogRelatedTools";
+import BlogDiscoveryCallCta from "@/components/blog/BlogDiscoveryCallCta";
+
+const PUBLISHED = "2026-05-07";
+const UPDATED = "2026-05-07";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline:
+      "SFDA Drug Master File (DMF) and Letter of Access: A Practical Guide for API Manufacturers and MAHs",
+    description:
+      "How DMFs are submitted to SFDA, how the Letter of Access works, what the restricted and open parts must contain, and where API manufacturers most often lose review time.",
+    image: "https://bytebeam.co/images/blog/sfda-drug-master-file.jpg",
+    author: {
+      "@type": "Person",
+      name: "Talal Bazerbachi",
+      jobTitle: "Founder, ByteBeam",
+      url: "https://bytebeam.co/about",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: PUBLISHED,
+    dateModified: UPDATED,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id":
+        "https://bytebeam.co/blog/sfda-drug-master-file-letter-of-access",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://bytebeam.co",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://bytebeam.co/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "SFDA Drug Master File and Letter of Access",
+        item: "https://bytebeam.co/blog/sfda-drug-master-file-letter-of-access",
+      },
+    ],
+  },
+];
+
+export default function SfdaDmfBlog() {
+  return (
+    <BlogLayout
+      title="SFDA Drug Master File (DMF) and Letter of Access: A Practical Guide for API Manufacturers and MAHs"
+      description="How DMFs are submitted to SFDA, how the Letter of Access works, what the restricted and open parts must contain, and where API manufacturers most often lose review time."
+      keywords="SFDA DMF, SFDA Drug Master File, Letter of Access SFDA, Active Substance Master File ASMF, API regulatory Saudi Arabia, DMF submission Saudi, restricted part DMF, open part DMF"
+      canonical="https://bytebeam.co/blog/sfda-drug-master-file-letter-of-access"
+      structuredData={structuredData}
+      category="Regulatory"
+      industry="Pharma"
+      readTime="13 min"
+      date={PUBLISHED}
+      updated={UPDATED}
+      author="Talal Bazerbachi"
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        For an API manufacturer, the <strong>Drug Master File (DMF)</strong> is the document that lets a finished-product MAH register a medicine in Saudi Arabia without ever seeing your manufacturing know-how. For the MAH, the DMF and the accompanying <strong>Letter of Access</strong> are the procedural plumbing that drops a third-party API into Module 3 of the eCTD. Get either piece wrong and the SFDA review stalls — sometimes for months — without anyone touching the actual scientific content.
+      </p>
+
+      <p>
+        This guide is written for in-house RA teams on both sides of the relationship: API manufacturers preparing DMFs for the Saudi market, and finished-product MAHs filing dossiers that reference third-party APIs. We cover how SFDA's DMF mechanism actually works, how the open and restricted parts split, what the Letter of Access must contain, where the most expensive review delays come from, and where AI agents now meaningfully compress the document workload around DMF preparation and lifecycle maintenance.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "SFDA does not accept stand-alone DMFs — the DMF supports a finished-product dossier (MAA) submitted by an MAH, and is represented in section 3.2.S of the eCTD.",
+          "The DMF splits into an open (applicant's) part visible to the MAH and a restricted (closed) part visible only to SFDA reviewers — protecting the API manufacturer's confidential know-how.",
+          "The Letter of Access is the legal instrument that grants SFDA permission to review the restricted part on behalf of a specific MAH for a specific finished product.",
+          "DMF structure follows ICH M4Q for content; SFDA aligns with FDA Type II DMF and EMA ASMF practice but adds Saudi-specific procedural requirements.",
+          "The most common SFDA RFIs on DMFs concern incomplete restricted-part submissions, mismatches between the DMF and the MAH's 3.2.S sections, and missing or expired Letters of Access.",
+        ]}
+      />
+
+      <h2>What is a Drug Master File under SFDA?</h2>
+
+      <p>
+        A Drug Master File is a confidential, comprehensive document that an API manufacturer submits to a regulator describing the chemistry, manufacturing, controls, and quality systems for an active pharmaceutical ingredient (or, in some cases, an excipient or packaging component). The DMF allows the API manufacturer to provide regulators with the data needed to review a finished product without disclosing proprietary manufacturing know-how to the finished-product company.<sup><a href="#ref1">[1]</a></sup>
+      </p>
+
+      <p>
+        SFDA's DMF mechanism receives Drug Master Files supporting drug substances (commonly known as APIs), excipients, and other materials used in preparation such as packaging components.<sup><a href="#ref2">[2]</a></sup> The Saudi DMF system is conceptually aligned with the EMA's <strong>Active Substance Master File (ASMF)</strong> procedure, which has the same purpose and the same open/closed split.<sup><a href="#ref3">[3]</a></sup> US FDA Type II DMFs serve the equivalent function in the United States.<sup><a href="#ref4">[4]</a></sup>
+      </p>
+
+      <p>
+        Critically, <strong>SFDA does not accept stand-alone DMF submissions</strong>. The DMF is always submitted in support of a finished-product Marketing Authorisation Application — meaning the API manufacturer cannot pre-register a DMF independently. The MAH submits its dossier via eSDR; the DMF is referenced from Module 3 (specifically section 3.2.S) of that dossier; the API manufacturer parallelly submits the restricted part directly to SFDA via the secure-link channel.<sup><a href="#ref2">[2]</a></sup>
+      </p>
+
+      <h2>The two-part structure: open and restricted</h2>
+
+      <p>
+        Every DMF splits into two parts. The procedural mechanics differ slightly between SFDA, EMA (ASMF), and FDA (Type II), but the underlying logic is identical.
+      </p>
+
+      <h3>Open part (Applicant's Part)</h3>
+
+      <p>
+        The open part is the section the MAH receives from the API manufacturer and includes in its own dossier. It contains <strong>non-confidential information</strong> that the MAH needs to take regulatory responsibility for the medicinal product: general API information, controls, specifications, container-closure system, stability summaries, and any information the API manufacturer is willing to share.<sup><a href="#ref5">[5]</a></sup> The MAH includes the open part in section 3.2.S of its eCTD pack.
+      </p>
+
+      <h3>Restricted part (Closed Part)</h3>
+
+      <p>
+        The restricted part contains the <strong>confidential manufacturing know-how</strong>: detailed synthesis routes, intermediate specifications, in-process controls, validation data, and proprietary process parameters. The MAH never sees this. The API manufacturer submits the restricted part directly to SFDA via the secure submission channel — historically by email or via an SFDA-provided secure link.<sup><a href="#ref2">[2]</a></sup>
+      </p>
+
+      <p>
+        SFDA reviewers read both parts together; the MAH's quality assessment relies on the open part plus the regulator's assessment of the restricted part. The mechanism preserves the API manufacturer's commercial position (recipes stay proprietary) while giving regulators the full picture they need to assess the medicinal product.
+      </p>
+
+      <h2>The Letter of Access — the legal instrument that ties it all together</h2>
+
+      <p>
+        The DMF and the MAH's dossier are independent submissions; the <strong>Letter of Access</strong> is the legal instrument that links them.<sup><a href="#ref6">[6]</a></sup> When an API manufacturer authorises a specific MAH to reference its DMF for a specific finished product, the manufacturer issues a Letter of Access — addressed to SFDA, on the manufacturer's letterhead — that grants permission for SFDA to review the restricted part on behalf of that MAH.
+      </p>
+
+      <p>
+        SFDA's Letter of Access expectations are specific:
+      </p>
+
+      <ul>
+        <li>The same identifying information used in the DMF cover letter must be repeated in the Letter of Access.</li>
+        <li>The Letter and the DMF form must both be on the API manufacturer's letterhead.</li>
+        <li>If the API is manufactured at multiple sites, every site must be listed explicitly.</li>
+        <li>The Letter must clearly identify the specific MAH and the specific finished product it authorises.</li>
+        <li>Letters are typically issued per-product, per-MAH — not as blanket authorisations.</li>
+      </ul>
+
+      <p>
+        For an API manufacturer supplying multiple MAHs across the GCC, Letter of Access management quickly becomes a non-trivial administrative workload. Each MAH-product pair gets its own letter; each new SKU triggers a new letter; expirations and renewals trigger updates. Tracking which Letters are active, which are pending renewal, and which have lapsed is the layer that most often catches teams out at audit.
+      </p>
+
+      <h2>What goes in each part — content expectations</h2>
+
+      <p>
+        DMF structure follows ICH M4Q, the common technical document quality module. Both parts populate sections of 3.2.S:
+      </p>
+
+      <h3>Section 3.2.S.1 — General Information (Open)</h3>
+      <p>API name, structure, properties. Always in the open part.</p>
+
+      <h3>Section 3.2.S.2 — Manufacture (Open + Restricted)</h3>
+      <p>The most consequential split. Manufacturer name and address: open. Description of manufacturing process and process controls: typically restricted. Controls of materials and critical steps: split based on what reveals proprietary know-how. Process validation: typically restricted.</p>
+
+      <h3>Section 3.2.S.3 — Characterisation (Open + Restricted)</h3>
+      <p>Elucidation of structure: open. Detailed impurity discussion (especially genotoxic impurities and their control strategy under <Link href="/blog/sfda-impurity-profile-ich-q3a-q3b-q3d">ICH Q3A/B/D</Link>): often restricted, depending on what reveals manufacturing know-how.</p>
+
+      <h3>Section 3.2.S.4 — Control of Drug Substance (Open)</h3>
+      <p>Specification, analytical procedures, validation, batch analysis, justification. Generally fully in the open part — the MAH needs to rely on the specification.</p>
+
+      <h3>Section 3.2.S.5 — Reference Standards (Open)</h3>
+      <p>Reference standard or materials. Open.</p>
+
+      <h3>Section 3.2.S.6 — Container Closure System (Open)</h3>
+      <p>Description and specifications of the API container closure. Open.</p>
+
+      <h3>Section 3.2.S.7 — Stability (Open + Restricted)</h3>
+      <p>Stability summary and conclusion: open. Detailed primary stability data and protocols: typically restricted.</p>
+
+      <p>
+        The split is not regulator-dictated; it's a commercial decision by the API manufacturer about what reveals their know-how. The principle is: the MAH needs enough information to take responsibility; the rest stays restricted.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="DMF"
+        variant="inline"
+        eyebrow="Bytebeam · Discovery call"
+        headline="DMF preparation and Letter of Access management — automation candidates"
+        body="If your team prepares DMFs for multiple finished-product MAHs across the GCC, walk us through your current process. We'll identify where AI agents can compress the per-Letter-of-Access overhead and where the per-product DMF assembly cycle is automatable."
+        ctaLabel="Book a 30-min DMF scoping call"
+        showProofOfPattern={false}
+      />
+
+      <h2>Why DMFs and Letters of Access eat in-house RA time</h2>
+
+      <p>
+        For an API manufacturer's RA team supplying multiple finished-product MAHs across multiple markets, DMF and Letter of Access work has a particular shape:
+      </p>
+
+      <ul>
+        <li><strong>Per-MAH duplication.</strong> The same API supplied to ten MAHs requires ten Letters of Access, ten parallel restricted-part submissions to SFDA (referenced from each MAH's eSDR submission), and ten ongoing tracking entries. The science is identical; the procedural overhead multiplies.</li>
+        <li><strong>Per-market open/restricted split decisions.</strong> SFDA's DMF expectations align with EMA ASMF and FDA Type II but with national-specific differences. The API manufacturer maintains a master DMF and produces market-specific variants — each of which requires a per-market split decision.</li>
+        <li><strong>Letter of Access lifecycle.</strong> Letters expire, MAH-product mappings change, manufacturing sites get added or retired. Maintaining the active-letters tracker across markets and MAHs is a structured but high-volume operational task.</li>
+        <li><strong>RFI cycles on the restricted part.</strong> SFDA RFIs on the restricted part go directly back to the API manufacturer — but the response timeline is bound to the MAH's submission clock, so coordination across organisations is the rate-limiting step.</li>
+      </ul>
+
+      <p>
+        For a finished-product MAH, the equivalent pain points sit on the other side of the relationship:
+      </p>
+
+      <ul>
+        <li><strong>Open-part section 3.2.S authoring.</strong> Receiving the open part from the API manufacturer and integrating it into the eCTD pack — formatting alignment, cross-references, consistency with the rest of Module 3.</li>
+        <li><strong>Letter of Access verification.</strong> Confirming that the Letter is current, addresses the right product, and lists every manufacturing site referenced in the dossier.</li>
+        <li><strong>RFI coordination.</strong> When SFDA RFIs arrive, classifying which apply to the MAH-controlled sections vs the DMF-controlled sections and routing accordingly.</li>
+      </ul>
+
+      <p>
+        The structural pattern — high volume, mostly procedural, with a smaller technical-judgment layer — makes DMF and LoA management a strong candidate for purpose-built automation. Generic regulatory document tools rarely understand the open/restricted split or the per-MAH lifecycle mechanics.
+      </p>
+
+      <h2>Benefits of automating DMF and Letter of Access workflows</h2>
+
+      <p>
+        Four measurable benefits when DMF/LoA work is automated with agents purpose-built for the workflow:
+      </p>
+
+      <ol>
+        <li><strong>Per-MAH variant generation.</strong> A master DMF + a Letter of Access template generate market-specific and MAH-specific variants automatically, with cross-document consistency checks.</li>
+        <li><strong>Letter of Access tracker.</strong> Active letters, expiration dates, MAH-product mappings, manufacturing-site coverage, signature status — structured retention rather than spreadsheet drift.</li>
+        <li><strong>Open/restricted split assistance.</strong> An agent that takes the master DMF and the target market and proposes the open/restricted split with citations to the relevant ICH M4Q section, surfacing borderline decisions for senior review.</li>
+        <li><strong>RFI routing.</strong> When SFDA RFIs arrive, automatic classification into MAH-controlled vs DMF-controlled sections speeds the response cycle for both parties.</li>
+      </ol>
+
+      <p>
+        Every automation step retains an audit trail — Letter status, restricted-part submissions, version history. SFDA and other GCC inspections increasingly examine DMF lifecycle evidence, and structured retention turns inspection prep into a side-effect of the normal workflow.
+      </p>
+
+      <h2>How to choose a DMF/LoA automation partner</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th>Why it matters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>SFDA DMF specifics</strong></td>
+            <td>Generic ICH-aligned tooling misses SFDA-specific submission mechanics (secure-link channel, MAH-anchored submission, no stand-alone DMFs).</td>
+          </tr>
+          <tr>
+            <td><strong>Multi-jurisdiction support</strong></td>
+            <td>API manufacturers typically supply markets beyond KSA. Tools that support EMA ASMF + FDA Type II + SFDA DMF reduce duplicated authoring work.</td>
+          </tr>
+          <tr>
+            <td><strong>Letter of Access tracker</strong></td>
+            <td>Active-letter management across MAH-product pairs is structured operational work, not document drafting. Tools that don't address this miss half the workload.</td>
+          </tr>
+          <tr>
+            <td><strong>Open/restricted split logic</strong></td>
+            <td>The split is a commercial decision, but the agent should propose the typical split with ICH M4Q section citations to anchor the conversation.</td>
+          </tr>
+          <tr>
+            <td><strong>Audit trail by default</strong></td>
+            <td>Every Letter, every restricted-part submission, every variant — versioned and retained. Inspection-ready as a default state.</td>
+          </tr>
+          <tr>
+            <td><strong>Process-led scoping</strong></td>
+            <td>API manufacturers' SOPs differ significantly between innovator API houses and high-volume generic API plants. Co-build with the team's existing workflow.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <BlogRelatedPosts
+        slugs={[
+          "sfda-ectd-submission-module-structure",
+          "sfda-drug-registration-guide-saudi-arabia",
+          "sfda-variations-type-ia-ib-ii-decision-guide",
+        ]}
+        heading="Related reading for API and CMC teams"
+        subtitle="Adjacent topics if you're scoping the broader SFDA submission lifecycle."
+      />
+
+      <h2>ByteBeam and SFDA DMF / Letter of Access automation</h2>
+
+      <p>
+        ByteBeam ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not generic copilots. Three are already in production for <strong>Module 1.3 labelling</strong>:
+      </p>
+
+      <ul>
+        <li><Link href="/sfda/spc-pil-generator"><strong>SmPC &amp; PIL Generator</strong></Link></li>
+        <li><Link href="/sfda/spc-pil-arabic-translator"><strong>Arabic SmPC &amp; PIL Translator</strong></Link></li>
+        <li><Link href="/sfda/dossier-gap-analysis"><strong>Dossier Gap Analysis</strong></Link></li>
+      </ul>
+
+      <p>
+        DMF preparation, Letter of Access management, and per-MAH variant generation are workloads we're actively scoping with API-manufacturer customer teams. The right shape of a DMF agent depends on whether you're an innovator API house (low-volume, high-confidentiality), a generic API manufacturer (high-volume, multi-MAH), or a finished-product MAH (open-part consumer, RFI router) — and whether you submit primarily to SFDA, broader GCC, or globally. That's why we don't ship a generic DMF copilot; we scope each agent to fit the team's existing workflow.
+      </p>
+
+      <h2>The future of DMF and Letter of Access management</h2>
+
+      <h3>Tighter GCC harmonisation pressure on DMFs</h3>
+
+      <p>
+        GCC harmonisation has primarily focused on finished-product registration pathways. DMFs and ASMFs are next on the harmonisation agenda — a single GCC-wide DMF that any GCC-bloc MAH can reference would dramatically reduce per-market overhead for API manufacturers. SFDA, as the most-developed GCC regulator, will likely lead any such initiative.
+      </p>
+
+      <h3>Electronic-only DMF submissions</h3>
+
+      <p>
+        The historical mix of email + secure-link + paper for the restricted-part submission is increasingly being consolidated into structured electronic-only channels. Expect SFDA's secure-link channel to evolve toward a fully electronic gateway aligned with the eSDR portal MAHs already use.
+      </p>
+
+      <h3>AI agents move from per-document drafting to portfolio-level lifecycle</h3>
+
+      <p>
+        The first generation of "AI for DMF" was about document drafting — generating section 3.2.S text from raw CMC inputs. The next generation is about <strong>portfolio-level lifecycle</strong>: an agent that knows your master DMF, all your active Letters of Access across all MAHs, every market-specific variant, and which RFIs are open against which products. The drafting layer becomes table stakes; the lifecycle layer becomes the differentiator.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="DMF"
+        eyebrow="Bytebeam · DMF scoping call"
+        headline="Scope your DMF and Letter of Access workflow — co-built around your team's process"
+        body="Walk us through how your team currently prepares DMFs, manages Letters of Access across MAH-product pairs, and routes SFDA RFIs. In 30 minutes we'll map the document touchpoints we'd automate first, and what stays with the QPPV / RA lead."
+        ctaLabel="Book a 30-min DMF scoping call"
+        expectations={[
+          "You walk us through your DMF preparation + Letter of Access lifecycle as it runs today",
+          "We map the document touchpoints we'd automate first across your MAH-product pairs",
+          "You leave with a written scoping summary — no commitment, no template demos",
+        ]}
+      />
+
+      <h2>Conclusion</h2>
+
+      <p>
+        SFDA's DMF mechanism is procedurally specific (no stand-alone submissions, MAH-anchored, secure-channel restricted part) but conceptually aligned with EMA ASMF and FDA Type II. For API manufacturers, the operational pain isn't the science — it's the per-MAH duplication and Letter of Access lifecycle. For finished-product MAHs, it's the open-part integration and RFI routing. Both sides benefit from purpose-built automation that understands the open/restricted split, the per-MAH lifecycle, and the SFDA-specific procedural mechanics. Generic regulatory tools rarely do; specialised agents co-built around the team's workflow do.
+      </p>
+
+      <BlogRelatedTools
+        eyebrow="Try the SFDA toolkit"
+        heading="The 3 SFDA Module 1.3 agents we've already shipped"
+        subtitle="Proof of pattern for the SFDA agents we co-build with in-house teams. Free first run on each, audit-trailed, DOCX out."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+
+      <ol className="text-sm">
+        <li id="ref1">
+          <a
+            href="https://www.fda.gov/drugs/forms-submission-requirements/drug-master-files-dmfs"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            US FDA — Drug Master Files (DMFs) reference page
+          </a>{" "}
+          — comparator framework for DMF concept and types.
+        </li>
+        <li id="ref2">
+          <a
+            href="https://www.gmp-compliance.org/gmp-news/saudi-food-and-drug-authority-publishes-drug-master-file-guidance"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ECA Academy — Saudi FDA publishes Drug Master File Guidance
+          </a>{" "}
+          (industry summary of the SFDA DMF guidance and submission mechanics).
+        </li>
+        <li id="ref3">
+          <a
+            href="https://www.ema.europa.eu/en/active-substance-master-file-procedure-scientific-guideline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            EMA — Active Substance Master File procedure (scientific guideline
+            page)
+          </a>
+          .
+        </li>
+        <li id="ref4">
+          <a
+            href="https://www.fda.gov/media/131861/download"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            US FDA — Drug Master Files Guidance for Industry (PDF)
+          </a>
+          .
+        </li>
+        <li id="ref5">
+          <a
+            href="https://www.ema.europa.eu/en/documents/report/final-guideline-active-substance-master-file-procedure-revision-4_en.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            EMA — Guideline on Active Substance Master File Procedure, Revision
+            4 (PDF)
+          </a>
+          .
+        </li>
+        <li id="ref6">
+          <a
+            href="https://ictr.johnshopkins.edu/wp-content/uploads/2014/01/DMF_LOA_30SEP13.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Johns Hopkins ICTR — Drug Master File Letter of Authorization
+            Guidance (PDF)
+          </a>{" "}
+          — academic-institutional reference for LoA structure.
+        </li>
+        <li id="ref7">
+          <a
+            href="https://www.sfda.gov.sa/sites/default/files/2025-08/Data-Human-Drugs-SubV4_0.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — 002-REQ-DS Data Requirements for Human Drugs Submission v4.0
+            (August 2025, PDF)
+          </a>
+          .
+        </li>
+        <li id="ref8">
+          <a
+            href="https://www.fda.gov/files/drugs/published/Completeness-Assessments-for-Type-II-API-DMFs-Under-GDUFA-Guidance-for-Industry.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            US FDA — Completeness Assessments for Type II API DMFs Under GDUFA
+            Guidance for Industry
+          </a>{" "}
+          — adjacent reference for DMF completeness criteria.
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: May 2026. SFDA DMF expectations evolve with each
+          guidance revision. Verify the current SFDA DMF and submission
+          requirements at{" "}
+          <a
+            href="https://sfda.gov.sa/en"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            sfda.gov.sa
+          </a>{" "}
+          before submission.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/sfda-drug-registration-guide-saudi-arabia.tsx
+++ b/client/src/pages/blog/sfda-drug-registration-guide-saudi-arabia.tsx
@@ -5,6 +5,7 @@ import BlogToolPromo from "@/components/blog/BlogToolPromo";
 import BlogRelatedTools from "@/components/blog/BlogRelatedTools";
 import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
 import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+import { SFDA_BOOKING_URL } from "@/lib/sfda/tools";
 
 const PUBLISHED = "2026-01-16";
 const UPDATED = "2026-05-07";
@@ -570,9 +571,9 @@ export default function SFDADrugRegistrationBlog() {
 
       <BlogRelatedPosts
         slugs={[
+          "sfda-pharmacovigilance-qppv-requirements",
+          "sfda-variations-type-ia-ib-ii-decision-guide",
           "no-code-document-automation-regulatory-teams-2026",
-          "arabic-ocr-challenges-solutions-2026",
-          "intelligent-document-processing-business-guide-2026",
         ]}
         heading="Related reading for RA teams"
         subtitle="Adjacent topics if you're operationalising SFDA submissions across a portfolio."
@@ -596,7 +597,7 @@ export default function SFDADrugRegistrationBlog() {
 
       <h3>How licensing works</h3>
 
-      <p>Each tool runs one free preview against your own document, so your team can see the output quality before any commercial conversation. To license for your full portfolio, integrate with your QMS, or run across multiple products, <a href="https://calendly.com/talal-bytebeam/sfda-discovery" target="_blank" rel="noopener noreferrer">walk through the output with us in a 30-minute call</a>. Per-team pricing is discussed on the call — there is no self-serve checkout, and the license is sold sales-led.</p>
+      <p>Each tool runs one free preview against your own document, so your team can see the output quality before any commercial conversation. To license for your full portfolio, integrate with your QMS, or run across multiple products, <a href={SFDA_BOOKING_URL} target="_blank" rel="noopener noreferrer">walk through the output with us in a 30-minute call</a>. Per-team pricing is discussed on the call — there is no self-serve checkout, and the license is sold sales-led.</p>
 
       <h2>The future of AI in SFDA regulatory affairs</h2>
 

--- a/client/src/pages/blog/sfda-ectd-submission-module-structure.tsx
+++ b/client/src/pages/blog/sfda-ectd-submission-module-structure.tsx
@@ -17,7 +17,7 @@ const structuredData = [
     headline:
       "SFDA eCTD Submission Format: Module 1 Regional Requirements & Common RFIs in 2026",
     description:
-      "How SFDA submissions actually work in eCTD: the GCC Module 1 specification, what each module contains, what triggers RFIs, and where in-house teams should focus automation.",
+      "How SFDA submissions work in eCTD: GCC Module 1 specification, module content, what triggers RFIs, and where in-house teams should focus automation.",
     image: "https://bytebeam.co/images/blog/sfda-ectd-modules.jpg",
     author: {
       "@type": "Person",
@@ -71,7 +71,7 @@ export default function SfdaEctdBlog() {
   return (
     <BlogLayout
       title="SFDA eCTD Submission Format: Module 1 Regional Requirements & Common RFIs in 2026"
-      description="How SFDA submissions actually work in eCTD: the GCC Module 1 specification, what each module contains, what triggers RFIs, and where in-house teams should focus automation."
+      description="How SFDA submissions work in eCTD: GCC Module 1 specification, module content, what triggers RFIs, and where in-house teams should focus automation."
       keywords="SFDA eCTD, GCC Module 1 specification, eCTD modules, ICH M4 CTD, ICH M8 eCTD v4.0, SFDA Guidance for Submission v5.0, Module 1.3 SmPC PIL, eCTD format Saudi Arabia, GHC Electronic Gateway"
       canonical="https://bytebeam.co/blog/sfda-ectd-submission-module-structure"
       structuredData={structuredData}
@@ -213,7 +213,7 @@ export default function SfdaEctdBlog() {
       />
 
       <p>
-        ByteBeam ships three single-purpose AI agents for SFDA Module 1.3 work specifically:
+        The <Link href="/sfda">ByteBeam SFDA toolkit</Link> ships three single-purpose AI agents for SFDA Module 1.3 work specifically:
       </p>
 
       <ul>

--- a/client/src/pages/blog/sfda-ectd-submission-module-structure.tsx
+++ b/client/src/pages/blog/sfda-ectd-submission-module-structure.tsx
@@ -1,0 +1,444 @@
+import { Link } from "wouter";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogToolsBanner from "@/components/blog/BlogToolsBanner";
+import BlogToolPromo from "@/components/blog/BlogToolPromo";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+import BlogRelatedTools from "@/components/blog/BlogRelatedTools";
+import BlogDiscoveryCallCta from "@/components/blog/BlogDiscoveryCallCta";
+
+const PUBLISHED = "2026-05-07";
+const UPDATED = "2026-05-07";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline:
+      "SFDA eCTD Submission Format: Module 1 Regional Requirements & Common RFIs in 2026",
+    description:
+      "How SFDA submissions actually work in eCTD: the GCC Module 1 specification, what each module contains, what triggers RFIs, and where in-house teams should focus automation.",
+    image: "https://bytebeam.co/images/blog/sfda-ectd-modules.jpg",
+    author: {
+      "@type": "Person",
+      name: "Talal Bazerbachi",
+      jobTitle: "Founder, ByteBeam",
+      url: "https://bytebeam.co/about",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: PUBLISHED,
+    dateModified: UPDATED,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id":
+        "https://bytebeam.co/blog/sfda-ectd-submission-module-structure",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://bytebeam.co",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://bytebeam.co/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "SFDA eCTD Submission Format",
+        item: "https://bytebeam.co/blog/sfda-ectd-submission-module-structure",
+      },
+    ],
+  },
+];
+
+export default function SfdaEctdBlog() {
+  return (
+    <BlogLayout
+      title="SFDA eCTD Submission Format: Module 1 Regional Requirements & Common RFIs in 2026"
+      description="How SFDA submissions actually work in eCTD: the GCC Module 1 specification, what each module contains, what triggers RFIs, and where in-house teams should focus automation."
+      keywords="SFDA eCTD, GCC Module 1 specification, eCTD modules, ICH M4 CTD, ICH M8 eCTD v4.0, SFDA Guidance for Submission v5.0, Module 1.3 SmPC PIL, eCTD format Saudi Arabia, GHC Electronic Gateway"
+      canonical="https://bytebeam.co/blog/sfda-ectd-submission-module-structure"
+      structuredData={structuredData}
+      category="Regulatory"
+      industry="Pharma"
+      readTime="14 min"
+      date={PUBLISHED}
+      updated={UPDATED}
+      author="Talal Bazerbachi"
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        Every SFDA pharmaceutical submission lives or dies on its <strong>eCTD pack</strong>. Get the structure right and the regulator's review focuses on the science. Get it wrong — wrong Module 1 form, wrong sequence number, wrong Module 1.3 labelling artefacts — and the validation phase alone can burn 30–60 days before a single scientific reviewer sees the dossier. For an in-house RA team running multiple submissions across the GCC, eCTD discipline is the difference between a 12-month and an 18-month time-to-market.
+      </p>
+
+      <p>
+        This guide is written for in-house RA teams already familiar with the CTD concept — what we cover here is the SFDA-specific procedural layer: which <strong>GCC Module 1 specification</strong> applies, where the regional divergences sit inside Module 1, what Modules 2–5 must look like, the validation rules that catch teams out, and where the highest-leverage automation opportunities are inside the eCTD workflow.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "SFDA accepts only eCTD submissions (since Feb 2019) and aligns Module 1 with the GCC Module 1 Specifications v1.5; Modules 2–5 follow ICH M4 CTD.",
+          "Module 1 is region-specific and contains the highest concentration of SFDA-specific procedural artefacts — application form, cover letter, CPP, GCC-specific documents, Module 1.3 labelling.",
+          "Module 1.3 (SmPC, PIL, labelling, packaging) is the single biggest source of avoidable RFIs in SFDA submissions.",
+          "ICH M8 eCTD v4.0 introduces a FHIR-based architecture that will eventually replace the v3.2.2 XML backbone — track but don't act yet for SFDA-only submissions.",
+          "Validation against the SFDA-approved eCTD publishing tools is mandatory; teams using non-approved tools fail at the door.",
+        ]}
+      />
+
+      <h2>What is the eCTD format?</h2>
+
+      <p>
+        The Common Technical Document (CTD) is the ICH-harmonised structure for organising drug registration dossiers — five modules covering administrative information (Module 1), summaries (Module 2), quality (Module 3), non-clinical (Module 4), and clinical (Module 5). The CTD itself is platform-neutral; the <strong>eCTD</strong> is the electronic implementation of that structure: a specific folder hierarchy plus an XML backbone that allows regulators to validate, track, and version dossiers programmatically across a product's lifecycle.<sup><a href="#ref1">[1]</a></sup>
+      </p>
+
+      <p>
+        SFDA mandated eCTD-only submissions for human medicines in February 2019, in line with the broader GCC harmonisation push.<sup><a href="#ref2">[2]</a></sup> All MAAs, variations, and renewals enter through the SFDA eSDR portal in eCTD format. Veterinary submissions retain the option of vNEES or paper CTD, but the human-pharmaceutical workstream is fully electronic.
+      </p>
+
+      <p>
+        Two specifications govern the file: the <strong>ICH M8</strong> eCTD specification (currently v3.2.2 in production globally, with v4.0 progressing toward implementation) defines the technical backbone — folder structure, file naming, XML schema, lifecycle operations.<sup><a href="#ref3">[3]</a></sup> The <strong>GCC Module 1 Specifications v1.5</strong>, published by SFDA, defines the region-specific Module 1 hierarchy that all GCC countries (Saudi Arabia, Bahrain, Kuwait, Oman, Qatar, UAE, Yemen) share.<sup><a href="#ref4">[4]</a></sup> A submitter prepares one eCTD pack per GCC country, with Module 1 differing per country and Modules 2–5 typically shared.
+      </p>
+
+      <h2>The five modules — what each one contains</h2>
+
+      <p>
+        The ICH-harmonised structure is the same everywhere. What differs by region is Module 1.
+      </p>
+
+      <h3>Module 1 — Regional administrative and prescribing information</h3>
+
+      <p>
+        Module 1 is the SFDA-specific module. The GCC Module 1 Specifications v1.5 defines the exact hierarchy SFDA accepts: cover letter, application form (now a 2025-edition Arabic-English bilingual form with QPPV / legal-rep / manufacturer fields), Certificate of Pharmaceutical Product (CPP), patent declaration, authorisation letters, and the full <strong>Module 1.3 labelling pack</strong> — SmPC, PIL, and labelling/packaging in both English and Arabic.<sup><a href="#ref4">[4]</a></sup><sup><a href="#ref5">[5]</a></sup>
+      </p>
+
+      <p>
+        Module 1 is also where the regulator's procedural metadata lives: sequence number, related-sequence references for variations, submission type, applicant identifiers, and country-specific documents (commercial registration, scientific office licence, agent appointment for foreign MAHs). Most validation failures at the SFDA gate come from Module 1 errors — wrong form version, missing CPP for a non-Schedule-X country, mismatched Arabic-English application-form fields.
+      </p>
+
+      <h3>Module 2 — Summaries</h3>
+
+      <p>
+        Module 2 contains the high-level summaries that bridge the technical modules: Quality Overall Summary (2.3), Non-Clinical Overview (2.4), Clinical Overview (2.5), Non-Clinical Written and Tabulated Summaries (2.6), Clinical Summary (2.7). These are author-driven narrative documents; SFDA expects them to be generated from electronic source documents — scanning is permitted only when unavoidable, with strict resolution and lossless-compression requirements.<sup><a href="#ref6">[6]</a></sup>
+      </p>
+
+      <h3>Module 3 — Quality (CMC)</h3>
+
+      <p>
+        Module 3 is the chemistry, manufacturing, and controls dossier. Drug substance sections (3.2.S) and drug product sections (3.2.P) are organised under the standardised ICH headings: General Information, Manufacture, Characterisation, Control, Stability. Most of an MAA's volume sits here — and most of the post-validation RFIs target API characterisation, stability data, and impurity profiling.
+      </p>
+
+      <h3>Module 4 — Non-clinical study reports</h3>
+
+      <p>
+        Module 4 contains the pharmacology and toxicology study reports. For generic applications, this module is typically slim (or supported by literature references in line with the SFDA biowaiver framework); for new chemical entities and biosimilars, it is substantial.
+      </p>
+
+      <h3>Module 5 — Clinical study reports</h3>
+
+      <p>
+        Module 5 contains the clinical efficacy and safety reports — biopharmaceutic studies, clinical pharmacology, efficacy studies, safety studies, post-marketing experience. Bioequivalence studies for generics live here. For verified / abridged-pathway submissions where the originator has been approved by USFDA or EMA, the SFDA workflow leverages this prior assessment to reduce the Module 5 review depth.<sup><a href="#ref7">[7]</a></sup>
+      </p>
+
+      <h2>The eCTD lifecycle — sequences, related sequences, and life-cycle operations</h2>
+
+      <p>
+        eCTD's defining feature isn't the folder structure — it's the <strong>lifecycle</strong>. Every submission for a product is a numbered sequence (0000 = original MAA, 0001 = first variation, and so on). Each sequence carries an XML backbone that declares which documents are new, replaced, appended, or deleted relative to the prior approved state. Reviewers can navigate a 5-year history of changes deterministically; the regulator's database treats the dossier as a versioned record rather than a document pile.<sup><a href="#ref3">[3]</a></sup>
+      </p>
+
+      <p>
+        For an in-house team, the practical implications:
+      </p>
+
+      <ul>
+        <li><strong>Sequence numbering must be continuous.</strong> Skipping or duplicating a sequence triggers a validation failure. Multi-team handovers are where this most often goes wrong.</li>
+        <li><strong>Related-sequence references matter.</strong> A variation submission must reference the sequence that established the current state of the document being changed. Wrong related-sequence = invalid lifecycle = rejection at validation.</li>
+        <li><strong>Document GUIDs are permanent.</strong> Once a document is referenced in the eCTD backbone with a specific GUID, that GUID identifies that document throughout the product's lifecycle. Re-using a GUID for a different document corrupts the lifecycle.</li>
+        <li><strong>Only SFDA-approved publishing tools are accepted.</strong> Submissions published with non-validated tools fail at the eSDR gateway. The choice of publishing software is itself a procurement decision for the in-house team.</li>
+      </ul>
+
+      <h2>ICH M8 eCTD v4.0 — track, but don't act yet for SFDA-only submissions</h2>
+
+      <p>
+        The ICH M8 Expert Working Group has been progressing the next major version of the eCTD specification — <strong>eCTD v4.0</strong> — for several years. v4.0 replaces the XML DTD-based backbone of v3.2.2 with a HL7 FHIR-based architecture, decouples the table-of-contents hierarchy from the core standard (so new sections can be added more flexibly), and introduces controlled vocabulary code lists for region-specific extensions.<sup><a href="#ref3">[3]</a></sup>
+      </p>
+
+      <p>
+        Globally, v4.0 implementation is staged — early-adopter regulators have published implementation packages, FDA has scheduled v4.0 acceptance, and EMA has published v4.0 guidance. SFDA is tracking the global rollout but has not announced a v4.0-only acceptance window. For SFDA-only submissions in 2026, v3.2.2 remains the operative specification. For multi-region submissions, plan for a v4.0 transition over the next 2–3 years and architect any in-house tooling to support both backbones.
+      </p>
+
+      <BlogToolsBanner
+        headline="Module 1.3 labelling is the single biggest source of avoidable SFDA RFIs"
+        subline="The SmPC, PIL, and Arabic translations carried inside every Module 1 are the most automatable layer of the entire eCTD pack — and the layer where bad output costs the most. Try the SFDA Module 1.3 toolkit free."
+      />
+
+      <h2>Module 1.3 — where most of the avoidable RFIs come from</h2>
+
+      <p>
+        Across published SFDA RFI patterns and the consultancies who track them, <strong>Module 1.3 (Labelling)</strong> consistently appears among the top three RFI generation areas — alongside Module 3 quality data and Module 5 clinical/bioequivalence data. The difference is that Module 3 and Module 5 RFIs usually reflect actual scientific gaps; Module 1.3 RFIs almost always reflect procedural and structural issues that a more disciplined authoring workflow would catch.
+      </p>
+
+      <p>The recurring categories:</p>
+
+      <ul>
+        <li><strong>SmPC structural drift from the QRD-derived layout adopted across GCC.</strong> Section ordering, section numbering, missing required sections — easy to fix, costly when missed.</li>
+        <li><strong>English / Arabic content drift.</strong> The Arabic PIL must mirror the English source. Sections present in one and not the other, terminology mismatches, or untranslated headings trigger RFIs.</li>
+        <li><strong>Generic translation that doesn't use SFDA-recognised regulatory phrasing.</strong> Calques and over-literal renderings get flagged. The SFDA expects a specific Arabic register.</li>
+        <li><strong>Misalignment between SmPC, PIL, and the new product data sheet.</strong> Brand name, MAH, manufacturer, pack sizes, storage statements — internal inconsistencies are the easiest RFIs for SFDA to spot.</li>
+        <li><strong>Missing or incorrect Module 1.3 metadata.</strong> File naming conventions, eCTD operation attribute mismatches.</li>
+      </ul>
+
+      <p>
+        For an in-house team running multiple submissions per quarter, the labelling layer is the highest-frequency, lowest-judgment work in the entire eCTD pack — which makes it the single highest-leverage place to deploy AI agents.
+      </p>
+
+      <BlogToolPromo
+        toolSlug="dossier-gap-analysis"
+        eyebrow="Pre-submission QC for Module 1.3"
+        hook="Catch SFDA labelling RFIs before they happen"
+      />
+
+      <p>
+        ByteBeam ships three single-purpose AI agents for SFDA Module 1.3 work specifically:
+      </p>
+
+      <ul>
+        <li><Link href="/sfda/spc-pil-generator"><strong>SmPC &amp; PIL Generator</strong></Link> — produces Module 1.3-aligned drafts from your originator pack, structured to the QRD-derived layout</li>
+        <li><Link href="/sfda/spc-pil-arabic-translator"><strong>Arabic SmPC &amp; PIL Translator</strong></Link> — regulator-recognised Arabic with RTL formatting and SFDA-accepted terminology</li>
+        <li><Link href="/sfda/dossier-gap-analysis"><strong>Dossier Gap Analysis</strong></Link> — pre-submission completeness sweep that catches the structural drift, English/Arabic mismatches, and metadata issues before they trigger RFIs</li>
+      </ul>
+
+      <p>
+        Each runs free on your own document, so the team can verify output quality before any commercial conversation. The output is editable DOCX — your QPPV signs off in normal Word review.
+      </p>
+
+      <h2>Why the eCTD pack consumes so much in-house RA time</h2>
+
+      <p>
+        For most SFDA submissions, the eCTD pack assembly is where the team spends the bulk of the calendar — not the underlying scientific work. Three structural reasons:
+      </p>
+
+      <ul>
+        <li><strong>Module 1 is procedurally dense.</strong> Application form (current 2025 edition, bilingual), CPP, Arabic translations, regional forms, sequence numbering, eSDR-specific metadata. Each item is small; together they consume time disproportionately.</li>
+        <li><strong>Module 1.3 is the labelling-propagation layer.</strong> Every change to the SmPC ripples to the PIL, the Arabic translations, and the labelling/packaging. Variations propagate through this layer endlessly.</li>
+        <li><strong>Modules 2–5 require Module-2 narrative authoring.</strong> The Quality / Non-Clinical / Clinical Overviews and Summaries are author-driven and consume senior RA / medical writing time.</li>
+      </ul>
+
+      <p>
+        The good news: the highest-volume, lowest-judgment layer (Module 1.3 labelling) is precisely the layer where AI agents are now mature enough to ship to production — which is what we've already built. The harder layers (Module 2 narrative authoring, Module 3 CMC writing, Module 5 clinical study writing) are co-build territory: they require deep team involvement and per-customer scoping.
+      </p>
+
+      <h2>Choosing tools for the eCTD workflow</h2>
+
+      <p>
+        The eCTD tool stack typically includes three distinct categories — be precise about which problem each one solves:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Tool category</th>
+            <th>What it solves</th>
+            <th>What it doesn't</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>eCTD publishing software</strong></td>
+            <td>Folder/backbone assembly, validation, sequence management, GUID tracking, regulator-portal export. SFDA accepts only validated tools.</td>
+            <td>Doesn't author content. You still write the SmPC / Module 2 narrative / Module 3 CMC text.</td>
+          </tr>
+          <tr>
+            <td><strong>SFDA Module 1.3 labelling agents</strong> (e.g. ByteBeam's 3 tools)</td>
+            <td>Generates SmPC + PIL drafts, Arabic translation with regulatory phrasing, pre-submission gap analysis. Reduces the layer that drives the most avoidable RFIs.</td>
+            <td>Doesn't replace eCTD publishing. Output is DOCX/structured content that still flows into the publishing tool.</td>
+          </tr>
+          <tr>
+            <td><strong>Module 2/3 authoring assistants</strong> (co-built per customer)</td>
+            <td>Module 2 narrative drafting from technical data. Module 3 CMC section authoring from existing dossier inputs.</td>
+            <td>Generic offerings rarely fit specific dossier conventions. Co-build with the team is the right pattern here.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <BlogRelatedPosts
+        slugs={[
+          "sfda-drug-registration-guide-saudi-arabia",
+          "sfda-variations-type-ia-ib-ii-decision-guide",
+          "sfda-pharmacovigilance-qppv-requirements",
+        ]}
+        heading="Related reading for SFDA submission teams"
+        subtitle="Adjacent topics if you're scoping the full submission lifecycle, not just initial registration."
+      />
+
+      <h2>The future of eCTD in SFDA</h2>
+
+      <p>
+        Three trends to track for in-house teams operating in the SFDA ecosystem.
+      </p>
+
+      <h3>eCTD v4.0 transition</h3>
+
+      <p>
+        The v3.2.2 to v4.0 transition will reach SFDA over the next 2–3 years following the global ICH M8 timeline.<sup><a href="#ref3">[3]</a></sup> The architectural shift to FHIR resources, the controlled vocabulary code lists, and the more-flexible TOC hierarchy are non-trivial — but the practical impact for in-house teams is largely absorbed by the eCTD publishing tool. The bigger long-term shift is that more flexible TOC hierarchies will let SFDA add region-specific sections without forcing a global ICH revision.
+      </p>
+
+      <h3>Tighter GCC harmonisation</h3>
+
+      <p>
+        The GCC Module 1 Specification has been stable at v1.5 for several years. Future revisions are likely to push further toward shared documents (CPPs, certificates) acceptable across more countries, reducing the per-country Module 1 divergence. The GCC Centralised Procedure already harmonises a slice of submissions; expect that slice to widen.
+      </p>
+
+      <h3>AI agents move from Module 1.3 to Module 2 narrative authoring</h3>
+
+      <p>
+        The Module 1.3 layer is where AI agents have already shipped — pattern-rich, structural, repeatable. The next frontier for in-house teams is Module 2 narrative authoring: Quality Overall Summary, Clinical Overview, Non-Clinical Overview. These are higher-judgment and harder to template, which is why we believe the right shape is co-build agents per customer, not generic copilots.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="eCTD"
+        eyebrow="Bytebeam · eCTD scoping call"
+        headline="Scope your eCTD authoring beyond Module 1.3 — co-built around your team's process"
+        body="Module 1.3 labelling is already covered by our 3 production SFDA tools. The next leverage layer is Module 2 narrative authoring and Module 3 CMC drafting. In 30 minutes we'll walk through your team's eCTD workflow and identify what we'd build next."
+        ctaLabel="Book a 30-min eCTD scoping call"
+        expectations={[
+          "You walk us through your eCTD authoring + publishing workflow as it runs today",
+          "We identify which CTD sections are realistic AI-agent candidates for your team",
+          "You leave with a written scoping summary — no commitment, no template demos",
+        ]}
+      />
+
+      <h2>Conclusion</h2>
+
+      <p>
+        The eCTD format is the technical backbone of every SFDA submission, and the GCC Module 1 specification is the regional layer where most procedural failures happen. For in-house teams, the question isn't whether to invest in eCTD discipline — eSDR rejections at the validation gate guarantee the answer is yes — but where to invest first. <strong>Module 1.3 labelling</strong> is the most automatable layer of the entire pack, the most frequent source of avoidable RFIs, and the layer where AI agents are mature enough to ship today. Higher-judgment layers (Module 2 narrative, Module 3 CMC authoring) follow as co-build engagements once the labelling layer is stabilised.
+      </p>
+
+      <BlogRelatedTools
+        eyebrow="Try the SFDA Module 1.3 toolkit"
+        heading="The 3 SFDA Module 1.3 agents we've already shipped"
+        subtitle="Each tool covers one step of the Module 1.3 labelling workflow. Free first run, audit-trailed, DOCX out."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+
+      <ol className="text-sm">
+        <li id="ref1">
+          ICH —{" "}
+          <a
+            href="https://www.ich.org/page/ich-electronic-common-technical-document-ectd-v40"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Electronic Common Technical Document (eCTD) v4.0
+          </a>{" "}
+          (ICH M8 Expert Working Group reference page).
+        </li>
+        <li id="ref2">
+          <a
+            href="https://www.biomapas.com/ectd-implementation-across-mena-region-what-is-the-current-status/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            eCTD implementation across the MENA region — current status
+          </a>{" "}
+          — industry analysis covering SFDA's February 2019 mandatory eCTD
+          adoption.
+        </li>
+        <li id="ref3">
+          <a
+            href="https://admin.ich.org/sites/default/files/inline-files/eCTDv4_0_SupportDocumentation_v1_4.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ICH M8 — eCTD v4.0 Support Documentation v1.4
+          </a>{" "}
+          (Implementation Package, technical schema reference).
+        </li>
+        <li id="ref4">
+          <a
+            href="https://sfda.gov.sa/sites/default/files/2021-03/GCC%20Module%201%20Specifications_v1.5-EN.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — GCC Module 1 Specifications v1.5
+          </a>{" "}
+          (official SFDA-published GCC regional specification).
+        </li>
+        <li id="ref5">
+          <a
+            href="https://www.sfda.gov.sa/sites/default/files/2022-10/GuidanceSubmissionV5.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — DS-G-003 Guidance for Submission Version 5.0
+          </a>{" "}
+          (official SFDA submission guidance).
+        </li>
+        <li id="ref6">
+          ICH —{" "}
+          <a
+            href="https://admin.ich.org/sites/default/files/inline-files/eCTD_Specification_v3_2_2_0.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            eCTD Specification v3.2.2
+          </a>{" "}
+          — currently operative ICH M8 specification.
+        </li>
+        <li id="ref7">
+          <a
+            href="https://www.sfda.gov.sa/sites/default/files/2025-10/VerificationAbridgedPathways3.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — DS-G-020 Verification &amp; Abridged Pathways v3.0
+          </a>{" "}
+          (October 2025) — official SFDA expedited-pathway guidance.
+        </li>
+        <li id="ref8">
+          <a
+            href="https://www.freyrsolutions.com/blog/your-2025-guide-checklist-to-sfdas-new-ectd-module-1-rules"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA's 2025 eCTD Module 1 rules — guide and checklist
+          </a>{" "}
+          — industry analysis of recent Module 1 form updates.
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: May 2026. SFDA submission guidance and the GCC Module 1
+          Specifications evolve over time. Verify the current versions against
+          the official SFDA regulations portal at{" "}
+          <a
+            href="https://sfda.gov.sa/en"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            sfda.gov.sa
+          </a>{" "}
+          before submitting.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/sfda-impurity-profile-ich-q3a-q3b-q3d.tsx
+++ b/client/src/pages/blog/sfda-impurity-profile-ich-q3a-q3b-q3d.tsx
@@ -1,0 +1,506 @@
+import { Link } from "wouter";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+import BlogRelatedTools from "@/components/blog/BlogRelatedTools";
+import BlogDiscoveryCallCta from "@/components/blog/BlogDiscoveryCallCta";
+
+const PUBLISHED = "2026-05-07";
+const UPDATED = "2026-05-07";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline:
+      "Impurity Profile for SFDA Drug Submissions: ICH Q3A, Q3B, Q3D, and M7 in Practice",
+    description:
+      "How to build a defensible impurity profile for SFDA submissions. Reporting, identification, and qualification thresholds under ICH Q3A/B; elemental impurities under Q3D; mutagenic impurities under M7.",
+    image: "https://bytebeam.co/images/blog/sfda-impurity-profile-ich-q3.jpg",
+    author: {
+      "@type": "Person",
+      name: "Talal Bazerbachi",
+      jobTitle: "Founder, ByteBeam",
+      url: "https://bytebeam.co/about",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: PUBLISHED,
+    dateModified: UPDATED,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id":
+        "https://bytebeam.co/blog/sfda-impurity-profile-ich-q3a-q3b-q3d",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://bytebeam.co",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://bytebeam.co/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Impurity Profile for SFDA Submissions",
+        item: "https://bytebeam.co/blog/sfda-impurity-profile-ich-q3a-q3b-q3d",
+      },
+    ],
+  },
+];
+
+export default function SfdaImpurityProfileBlog() {
+  return (
+    <BlogLayout
+      title="Impurity Profile for SFDA Drug Submissions: ICH Q3A, Q3B, Q3D, and M7 in Practice"
+      description="How to build a defensible impurity profile for SFDA submissions. Reporting, identification, and qualification thresholds under ICH Q3A/B; elemental impurities under Q3D; mutagenic impurities under M7."
+      keywords="ICH Q3A SFDA, ICH Q3B impurities, ICH Q3D elemental impurities, ICH M7 mutagenic impurities, impurity profile drug substance, qualification threshold ICH, nitrosamine impurities SFDA, NDSRI assessment"
+      canonical="https://bytebeam.co/blog/sfda-impurity-profile-ich-q3a-q3b-q3d"
+      structuredData={structuredData}
+      category="Regulatory"
+      industry="Pharma"
+      readTime="14 min"
+      date={PUBLISHED}
+      updated={UPDATED}
+      author="Talal Bazerbachi"
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        For any innovator or complex-generic submission to SFDA, the <strong>impurity profile</strong> is one of the most-scrutinised technical packages in the entire dossier. Module 3.2.S.3.2 (drug substance impurities), Module 3.2.P.5.5 (drug product degradation products), the Q3D elemental risk assessment, and the M7 mutagenic-impurity assessment together define what regulators see when they evaluate the chemistry of a new product. Get the thresholds right, the qualification logic correct, and the structural alerts addressed — and the review proceeds. Get them wrong and the RFI cycle is one of the most expensive in pharmaceutical regulatory affairs.
+      </p>
+
+      <p>
+        This guide is written for in-house CMC and RA teams preparing impurity profiles for SFDA submissions. SFDA aligns with the ICH Q3 and M7 series, so the technical framework described here applies to GCC submissions broadly — but the procedural integration into the SFDA Module 3 expectations is the layer where regional specifics matter. We cover the Q3A/Q3B threshold logic, the Q3D risk-based elemental approach, the M7 mutagenic-impurity assessment including the nitrosamine layer, and where AI agents now meaningfully compress the impurity-profile compilation workload for in-house teams.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "ICH Q3A (drug substance) and Q3B (drug product) define three threshold tiers — reporting, identification, qualification — calibrated against the maximum daily dose.",
+          "ICH Q3D (R2) requires a risk-based elemental impurity assessment for 24 elements, with PDEs (Permitted Daily Exposures) calibrated by class and route of administration.",
+          "ICH M7 (R2, 2023) is the primary framework for DNA-reactive mutagenic impurities — including the structural-alert classification, TTC-based limits, and the nitrosamine extension.",
+          "For new drug substances, the impurity profile must justify limits, identify all impurities above the identification threshold, and qualify all impurities above the qualification threshold.",
+          "M7(R3) and the formal ICH workstream on N-nitrosamines (adopted June 2024) signal that nitrosamine assessment is moving from regulator-by-regulator practice toward a unified ICH framework.",
+        ]}
+      />
+
+      <h2>What is an impurity profile?</h2>
+
+      <p>
+        An impurity profile is the structured description of every impurity present in a drug substance or drug product, with its origin, structure, abundance, control strategy, and toxicological qualification. For SFDA submissions, the impurity profile is split across multiple Module 3 sections: drug substance impurities in 3.2.S.3.2, drug product degradation products in 3.2.P.5.5, elemental impurities under the ICH Q3D risk-based framework, and mutagenic impurities under ICH M7. Each section has its own technical framework, but they share the same purpose: demonstrate to the regulator that every impurity above the relevant threshold has been identified, quantified, controlled, and qualified at the proposed limit.<sup><a href="#ref1">[1]</a></sup>
+      </p>
+
+      <p>
+        The frameworks SFDA expects are not SFDA-specific; they are the ICH Q3 series (Q3A, Q3B, Q3C for residual solvents, Q3D for elemental impurities) and the ICH M7 series for mutagenic impurities. SFDA aligns with these as a member of the GCC harmonisation framework and as a regulator that adopted ICH-aligned practice in line with its 2021 ICH membership.
+      </p>
+
+      <h2>ICH Q3A — Impurities in new drug substances</h2>
+
+      <p>
+        ICH Q3A(R2) defines the framework for impurities arising in active pharmaceutical ingredients during synthesis, isolation, or storage.<sup><a href="#ref2">[2]</a></sup> The guideline covers three categories: organic impurities (synthesis-derived), inorganic impurities (reagents, catalysts, heavy metals — though now largely superseded by Q3D for elementals), and residual solvents (covered by Q3C).
+      </p>
+
+      <p>
+        The defining feature of Q3A is the <strong>three-threshold framework</strong>, calibrated against the maximum daily dose of the API:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Threshold</th>
+            <th>What it requires</th>
+            <th>Typical value (max daily dose ≤ 2 g/day)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Reporting threshold</strong></td>
+            <td>Impurity must be reported in the analytical results above this level</td>
+            <td>0.05% (lower for higher daily doses)</td>
+          </tr>
+          <tr>
+            <td><strong>Identification threshold</strong></td>
+            <td>Impurity must be structurally identified above this level</td>
+            <td>0.10% or 1.0 mg/day intake (whichever is lower)</td>
+          </tr>
+          <tr>
+            <td><strong>Qualification threshold</strong></td>
+            <td>Impurity must be qualified — i.e. supported by toxicological data demonstrating safety at the proposed limit</td>
+            <td>0.15% or 1.0 mg/day intake (whichever is lower)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The thresholds tighten as daily dose increases. For an API with maximum daily dose &gt; 2 g/day, the qualification threshold drops to 0.05% — meaning impurities at much lower abundances must still be qualified.<sup><a href="#ref3">[3]</a></sup>
+      </p>
+
+      <p>
+        For an in-house CMC team, the operational consequence is that the impurity profile compilation requires three parallel data streams: <strong>(1)</strong> analytical data from stability and batch testing showing actual impurity levels, <strong>(2)</strong> structural identification (typically by HPLC-MS, NMR, or reference comparison), and <strong>(3)</strong> qualification data — either literature, comparator data, or dedicated toxicology studies. Each impurity above the identification threshold needs all three; missing any one drives an RFI.
+      </p>
+
+      <h2>ICH Q3B — Degradation products in new drug products</h2>
+
+      <p>
+        ICH Q3B(R2) extends the same three-threshold framework to <strong>degradation products formed in the drug product</strong> during manufacturing or storage.<sup><a href="#ref4">[4]</a></sup> The thresholds are calibrated identically against the maximum daily dose.
+      </p>
+
+      <p>
+        The practical distinction from Q3A: drug product degradation includes impurities that don't exist in the drug substance. Hydrolysis products from formulation excipients, oxidative degradants from the dosage form, photolytic products from packaging exposure — all require the same threshold-driven identification and qualification, but they sit in 3.2.P.5.5 (drug product specifications and analytical procedures justification) rather than 3.2.S.
+      </p>
+
+      <p>
+        Stability studies under <strong>ICH Q1A(R2)</strong> are the primary data source for Q3B. The impurity profile section of the SFDA submission must show: which degradation products appear at long-term and accelerated conditions, at what levels relative to the threshold tiers, and what the proposed shelf-life specification limits are based on the data.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="impurity profile"
+        variant="inline"
+        eyebrow="Bytebeam · Discovery call"
+        headline="Impurity profile compilation — automation candidates"
+        body="If your CMC team prepares ICH Q3A/B/D and M7 impurity profiles for SFDA submissions recurringly, walk us through your current process. We'll identify where AI agents can compress the threshold-by-threshold compilation cycle and where the work stays with the senior CMC reviewer."
+        ctaLabel="Book a 30-min impurity scoping call"
+        showProofOfPattern={false}
+      />
+
+      <h2>ICH Q3D — Elemental impurities</h2>
+
+      <p>
+        Until ICH Q3D was finalised, "inorganic impurities" sat awkwardly inside Q3A — covered conceptually but not with the rigorous framework that the post-2018 understanding of elemental risk demanded. ICH Q3D(R2), Step 4 in 2022, supersedes that approach with a comprehensive risk-based framework for 24 elemental impurities.<sup><a href="#ref5">[5]</a></sup>
+      </p>
+
+      <p>The Q3D framework has four operating principles:</p>
+
+      <ol>
+        <li><strong>24 elements, three classes.</strong> Class 1 (As, Cd, Hg, Pb) are highest-toxicity elements that require evaluation for all sources. Class 2A (Co, Ni, V) require evaluation in all routes. Class 2B (Ag, Au, Ir, Os, Pd, Pt, Rh, Ru, Se, Tl) require evaluation only when intentionally added. Class 3 (Ba, Cr, Cu, Li, Mo, Sb, Sn) have low oral toxicity but need evaluation for parenteral and inhalation routes.</li>
+        <li><strong>PDEs (Permitted Daily Exposures) by route.</strong> Oral, parenteral, and inhalation routes have different PDE values per element. The same element has different acceptable limits depending on how it enters the body.</li>
+        <li><strong>Risk-based assessment, not blanket testing.</strong> The MAH evaluates the contribution of each potential elemental source — drug substance, excipients, manufacturing equipment, container-closure system — and only those sources contributing meaningfully to the total need controlled limits in the specification.</li>
+        <li><strong>Control strategy must be documented.</strong> The elemental impurity risk assessment is itself a section of the dossier — typically in 3.2.P.5.6 or as a stand-alone Q3D risk assessment.</li>
+      </ol>
+
+      <p>
+        The Q3D risk assessment is a <strong>document-heavy compilation task</strong>. The team gathers elemental data from every excipient supplier, every equipment material certificate, every container component, and assembles the per-element PDE-vs-actual analysis into the dossier section. For complex formulations with multiple excipients across multiple suppliers, this is exactly the structured-but-mechanical work that AI agents compress effectively when scoped to the specific data sources the team uses.
+      </p>
+
+      <h2>ICH M7 — Mutagenic impurities and the nitrosamine extension</h2>
+
+      <p>
+        ICH M7(R2), Step 4 in 2023, is the framework for assessing and controlling DNA-reactive (mutagenic) impurities — the highest-risk category, where the carcinogenic potential demands a separate analytical and toxicological treatment.<sup><a href="#ref6">[6]</a></sup>
+      </p>
+
+      <p>The M7 framework operates in five steps:</p>
+
+      <ol>
+        <li><strong>Identify potential impurities.</strong> Synthesis intermediates, byproducts, degradation products, reagents — the full list of compounds that could appear in the API or drug product.</li>
+        <li><strong>Apply the (Q)SAR analysis.</strong> Two complementary in-silico approaches (one rule-based / expert-system, one statistical) screen each impurity for structural alerts indicating mutagenic potential.</li>
+        <li><strong>Classify into 5 classes.</strong> Class 1 (known mutagenic carcinogen, including the cohort-of-concern), Class 2 (known mutagen, unknown carcinogenic potential), Class 3 (alerting structure, unrelated to API), Class 4 (alerting structure, related to API which is non-mutagenic), Class 5 (no alert or sufficient data to demonstrate non-mutagenicity).</li>
+        <li><strong>Apply Acceptable Intake limits.</strong> For Class 1, 2, and 3 impurities, calculate the acceptable intake using either the TTC (Threshold of Toxicological Concern, 1.5 µg/day for chronic exposure) or compound-specific data where available.</li>
+        <li><strong>Define control strategy.</strong> Where a potential mutagenic risk is identified, develop process and analytical controls ensuring impurity levels remain at or below the acceptable cancer-risk level.<sup><a href="#ref7">[7]</a></sup></li>
+      </ol>
+
+      <p>
+        For an in-house team, M7 is a <strong>cross-disciplinary exercise</strong>: synthesis chemists list potential impurities, toxicologists or contract assessors run the (Q)SAR, regulatory writes the assessment for Module 3.2.S.3.2 (or a dedicated M7 assessment annex). The compilation overhead is significant.
+      </p>
+
+      <h3>The nitrosamine extension</h3>
+
+      <p>
+        The 2018–2020 nitrosamine crisis (sartans, ranitidine, metformin) drove a major change in regulator focus. ICH M7(R2) addresses nitrosamines but the comprehensive harmonised framework is still developing — the new ICH workstream on N-nitrosamines was formally adopted at the ICH meeting in Fukuoka in June 2024, and M7(R3) is expected to introduce a structurally-quantitative carcinogenic-potency approach for nitrosamines.<sup><a href="#ref8">[8]</a></sup>
+      </p>
+
+      <p>
+        For SFDA submissions in 2026, this means: the nitrosamine assessment is currently a layered exercise drawing on EMA and FDA guidance for specific N-nitrosamine acceptable intakes (AI), the FDA NDSRI database for known nitrosamine drug substance-related impurities, and the M7 framework for novel nitrosamines. SFDA expects the assessment to be present and current; teams need to track the EMA / FDA AI updates because they are referenced in SFDA practice.
+      </p>
+
+      <h2>Why impurity profile compilation eats senior CMC time</h2>
+
+      <p>
+        Across the in-house teams we work with, impurity profile compilation has a particular operational shape:
+      </p>
+
+      <ul>
+        <li><strong>Multi-source data aggregation.</strong> Q3D requires elemental data from every excipient supplier and equipment material. M7 requires synthesis-pathway analysis from R&amp;D plus (Q)SAR results from a third-party assessor. Q3A/B require analytical data from stability + batch testing. The team's role is mostly aggregation and structuring rather than novel science.</li>
+        <li><strong>Per-product re-compilation.</strong> Each new product, each variation that changes the synthesis route, each new excipient triggers a re-compilation. The framework is the same; the data inputs change.</li>
+        <li><strong>RFI vulnerability is high.</strong> Module 3.2.S.3.2 and the M7 assessment are among the most-RFI-generating dossier sections. Common RFIs: missing qualification for impurities just above the threshold; unjustified specification limits; incomplete elemental risk assessment; M7 (Q)SAR documented insufficiently.</li>
+        <li><strong>The judgmental layer is small.</strong> Most of the time goes into structured compilation; the actual scientific judgment (do we accept this impurity at this level given this clinical context?) is a fraction of the total effort.</li>
+      </ul>
+
+      <p>
+        This pattern — high-volume structured compilation with a smaller judgment layer — is exactly the shape that AI agents purpose-built for impurity-profile work compress effectively. Generic CMC writing tools rarely understand the threshold logic; specialised agents do.
+      </p>
+
+      <h2>Benefits of automating impurity profile compilation</h2>
+
+      <ol>
+        <li><strong>Threshold logic automation.</strong> Given the maximum daily dose and the analytical results, an agent calculates the applicable Q3A/B thresholds and flags impurities above each threshold tier — surfacing the ones that need identification or qualification rather than burying them in a spreadsheet.</li>
+        <li><strong>Q3D risk assessment compilation.</strong> Excipient elemental data + equipment material data + container-closure data → structured per-element PDE-vs-actual analysis with the source-by-source breakdown ICH Q3D(R2) expects.</li>
+        <li><strong>M7 assessment drafting.</strong> Synthesis impurity list + (Q)SAR output → drafted M7 assessment with class assignments, TTC-based or compound-specific limits, and the control-strategy section ready for senior review.</li>
+        <li><strong>Nitrosamine tracking.</strong> Maintaining the current nitrosamine assessment against the moving target of EMA/FDA AI updates and the FDA NDSRI database — a monitoring task that compounds across portfolios.</li>
+      </ol>
+
+      <p>
+        Output stays editable. The senior CMC reviewer signs off in normal Word/Excel review. The compilation work that used to take 4–8 weeks per submission moves into days; the judgmental sign-off stays where it belongs.
+      </p>
+
+      <h2>How to choose an impurity profile automation partner</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th>Why it matters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>ICH Q3A/B threshold-aware</strong></td>
+            <td>Tools that don't automatically calibrate thresholds against maximum daily dose miss the entire point.</td>
+          </tr>
+          <tr>
+            <td><strong>ICH Q3D source-by-source assessment</strong></td>
+            <td>The agent should structure the elemental risk assessment around drug substance, excipients, equipment, and container-closure — the four mandatory source categories.</td>
+          </tr>
+          <tr>
+            <td><strong>ICH M7 (Q)SAR integration</strong></td>
+            <td>(Q)SAR output needs to flow into the M7 assessment without manual re-entry. Generic LLM tools without (Q)SAR integration miss the technical heart of M7.</td>
+          </tr>
+          <tr>
+            <td><strong>Nitrosamine database tracking</strong></td>
+            <td>EMA/FDA AI values and the NDSRI database update frequently. Tools that freeze on training data miss the most current limits.</td>
+          </tr>
+          <tr>
+            <td><strong>SFDA Module 3 section mapping</strong></td>
+            <td>Output must map to 3.2.S.3.2, 3.2.P.5.5, 3.2.P.5.6 — the dossier sections SFDA reads — not generic "impurity report" formats.</td>
+          </tr>
+          <tr>
+            <td><strong>Audit trail by default</strong></td>
+            <td>Every threshold calculation, every classification decision, every (Q)SAR result retained — inspection-ready as a side-effect.</td>
+          </tr>
+          <tr>
+            <td><strong>Process-led scoping</strong></td>
+            <td>Innovator workflows differ from generic workflows. Co-build with the team's existing CMC SOPs.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <BlogRelatedPosts
+        slugs={[
+          "sfda-drug-master-file-letter-of-access",
+          "sfda-ectd-submission-module-structure",
+          "sfda-drug-registration-guide-saudi-arabia",
+        ]}
+        heading="Related reading for CMC and RA teams"
+        subtitle="Adjacent topics if you're scoping the broader Module 3 quality submission."
+      />
+
+      <h2>ByteBeam and SFDA impurity profile automation</h2>
+
+      <p>
+        ByteBeam ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not generic copilots. Three are already in production for <strong>Module 1.3 labelling</strong>:
+      </p>
+
+      <ul>
+        <li><Link href="/sfda/spc-pil-generator"><strong>SmPC &amp; PIL Generator</strong></Link></li>
+        <li><Link href="/sfda/spc-pil-arabic-translator"><strong>Arabic SmPC &amp; PIL Translator</strong></Link></li>
+        <li><Link href="/sfda/dossier-gap-analysis"><strong>Dossier Gap Analysis</strong></Link></li>
+      </ul>
+
+      <p>
+        Impurity profile compilation — Q3A/B threshold compilation, Q3D risk assessment, M7 assessment drafting, nitrosamine tracking — is one of the workloads we're actively scoping with customer CMC teams. The right shape of an impurity-profile agent depends on whether you're an innovator (small volume, long lead time per submission) or a generic manufacturer (high volume, similar synthetic chemistries), and on whether your team uses external (Q)SAR providers or maintains in-house software. That's why we don't ship a generic impurity copilot; we scope each agent to fit the team's existing workflow and data sources.
+      </p>
+
+      <h2>The future of impurity assessment in SFDA-regulated submissions</h2>
+
+      <h3>M7(R3) and the formal nitrosamine workstream</h3>
+
+      <p>
+        The June 2024 ICH adoption of a formal N-nitrosamine workstream signals that the current patchwork of EMA / FDA / regulator-specific nitrosamine guidance is moving toward a unified ICH framework. M7(R3) is expected to incorporate a quantitative structure-based carcinogenic-potency approach.<sup><a href="#ref8">[8]</a></sup> Teams that have built nitrosamine assessment as a one-off response to specific cases will need to migrate to a structured framework over the next 1–2 years.
+      </p>
+
+      <h3>Risk-based controls deepen further</h3>
+
+      <p>
+        Q3D's risk-based approach (rather than blanket testing) is increasingly the regulatory default — and this philosophy is spreading into other impurity domains. Future revisions of Q3A/B are likely to deepen the risk-based qualification logic, allowing more leverage of comparator data and literature qualification for impurities at lower abundances.
+      </p>
+
+      <h3>(Q)SAR + AI combine in mutagenic-impurity assessment</h3>
+
+      <p>
+        The traditional (Q)SAR step in M7 has been a discrete software task. The next generation is hybrid: (Q)SAR + LLM-based literature search + chemistry-aware reasoning over the structural alert, all integrated into the dossier-assembly workflow. The assessment that took weeks becomes a structured document workflow with senior-CMC review at the judgment-critical points.
+      </p>
+
+      <h3>SFDA tracks ICH revisions in real time</h3>
+
+      <p>
+        SFDA's 2021 ICH membership and continued maturity-level work mean the regulator tracks ICH revisions promptly. For in-house teams, this means impurity-profile practice for SFDA submissions follows the global ICH state-of-art rather than a Saudi-specific divergence — which is good news for the broader applicability of any automation investment.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="impurity profile"
+        eyebrow="Bytebeam · Impurity profile scoping call"
+        headline="Scope your impurity profile compilation — co-built around your team's CMC process"
+        body="Walk us through how your team currently compiles ICH Q3A/B/D and M7 impurity profiles for SFDA submissions. In 30 minutes we'll map the document touchpoints we'd automate first, and what stays with the senior CMC reviewer."
+        ctaLabel="Book a 30-min impurity scoping call"
+        expectations={[
+          "You walk us through your impurity profile compilation workflow as it runs today",
+          "We map the document touchpoints we'd automate first across Q3A/B/D and M7",
+          "You leave with a written scoping summary — no commitment, no template demos",
+        ]}
+      />
+
+      <h2>Conclusion</h2>
+
+      <p>
+        Impurity profile compilation is one of the highest-stakes technical packages in any SFDA submission. The frameworks are ICH-standard (Q3A, Q3B, Q3D, M7) and SFDA aligns with them; the operational pain is the structured compilation of multi-source data into the threshold-driven analyses regulators expect. For an in-house CMC team running multiple submissions per year, the compilation work is a strong candidate for purpose-built automation — but not for a generic copilot. The threshold logic is too specific, the (Q)SAR integration too technical, and the nitrosamine tracking too dynamic for a one-size-fits-all tool. Co-built agents that respect the team's existing data sources and SOPs are the right shape.
+      </p>
+
+      <BlogRelatedTools
+        eyebrow="Try the SFDA toolkit"
+        heading="The 3 SFDA Module 1.3 agents we've already shipped"
+        subtitle="Proof of pattern for the SFDA agents we co-build with in-house teams. Free first run on each, audit-trailed, DOCX out."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+
+      <ol className="text-sm">
+        <li id="ref1">
+          <a
+            href="https://onlinelibrary.wiley.com/doi/abs/10.1002/9781118971147.ch6"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Impurities in New Drug Substances and New Drug Products
+          </a>{" "}
+          — peer-reviewed ICH Quality Guidelines reference (Wiley).
+        </li>
+        <li id="ref2">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/Q3A(R2)%20Guideline.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Q3A(R2) Impurities in New Drug Substances
+          </a>{" "}
+          (PDF, Step 4).
+        </li>
+        <li id="ref3">
+          <a
+            href="https://www.ema.europa.eu/en/ich-q3a-r2-impurities-new-drug-substances-scientific-guideline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            EMA — ICH Q3A(R2) scientific guideline page
+          </a>
+          .
+        </li>
+        <li id="ref4">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/Q3B(R2)%20Guideline.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Q3B(R2) Impurities in New Drug Products
+          </a>{" "}
+          (PDF, Step 4).
+        </li>
+        <li id="ref5">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/Q3D-R2_Guideline_Step4_2022_0308.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Q3D(R2) Guideline for Elemental Impurities
+          </a>{" "}
+          (PDF, Step 4, March 2022).
+        </li>
+        <li id="ref6">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/ICH_M7(R2)_Guideline_Step4_2023_0216_0.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            M7(R2) Assessment and Control of DNA Reactive (Mutagenic) Impurities
+          </a>{" "}
+          (PDF, Step 4, February 2023).
+        </li>
+        <li id="ref7">
+          <a
+            href="https://www.ema.europa.eu/en/ich-m7-assessment-control-dna-reactive-mutagenic-impurities-pharmaceuticals-limit-potential-carcinogenic-risk-scientific-guideline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            EMA — ICH M7 scientific guideline page
+          </a>
+          .
+        </li>
+        <li id="ref8">
+          <a
+            href="https://link.springer.com/article/10.1186/s41021-025-00349-5"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Guidelines for the assessment and control of mutagenic impurities in
+            pharmaceuticals
+          </a>
+          . Genes and Environment (Springer Nature, 2025) — peer-reviewed
+          summary including the M7(R3) and ICH N-nitrosamine workstream.
+        </li>
+        <li id="ref9">
+          <a
+            href="https://pmc.ncbi.nlm.nih.gov/articles/PMC12723853/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Guidelines for the assessment and control of mutagenic impurities in
+            pharmaceuticals (PMC)
+          </a>{" "}
+          — open-access version of the same Springer Nature analysis.
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: May 2026. ICH guidelines and SFDA practice evolve over
+          time — verify the current ICH guideline version on the{" "}
+          <a
+            href="https://www.ich.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ICH website
+          </a>{" "}
+          and the current SFDA expectation against the official SFDA regulations
+          portal at{" "}
+          <a
+            href="https://sfda.gov.sa/en"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            sfda.gov.sa
+          </a>{" "}
+          before submission.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/sfda-impurity-profile-ich-q3a-q3b-q3d.tsx
+++ b/client/src/pages/blog/sfda-impurity-profile-ich-q3a-q3b-q3d.tsx
@@ -15,7 +15,7 @@ const structuredData = [
     headline:
       "Impurity Profile for SFDA Drug Submissions: ICH Q3A, Q3B, Q3D, and M7 in Practice",
     description:
-      "How to build a defensible impurity profile for SFDA submissions. Reporting, identification, and qualification thresholds under ICH Q3A/B; elemental impurities under Q3D; mutagenic impurities under M7.",
+      "Build a defensible impurity profile for SFDA submissions: ICH Q3A/B thresholds, Q3D elemental impurities, and M7 mutagenic-impurity assessment.",
     image: "https://bytebeam.co/images/blog/sfda-impurity-profile-ich-q3.jpg",
     author: {
       "@type": "Person",
@@ -69,7 +69,7 @@ export default function SfdaImpurityProfileBlog() {
   return (
     <BlogLayout
       title="Impurity Profile for SFDA Drug Submissions: ICH Q3A, Q3B, Q3D, and M7 in Practice"
-      description="How to build a defensible impurity profile for SFDA submissions. Reporting, identification, and qualification thresholds under ICH Q3A/B; elemental impurities under Q3D; mutagenic impurities under M7."
+      description="Build a defensible impurity profile for SFDA submissions: ICH Q3A/B thresholds, Q3D elemental impurities, and M7 mutagenic-impurity assessment."
       keywords="ICH Q3A SFDA, ICH Q3B impurities, ICH Q3D elemental impurities, ICH M7 mutagenic impurities, impurity profile drug substance, qualification threshold ICH, nitrosamine impurities SFDA, NDSRI assessment"
       canonical="https://bytebeam.co/blog/sfda-impurity-profile-ich-q3a-q3b-q3d"
       structuredData={structuredData}
@@ -310,7 +310,7 @@ export default function SfdaImpurityProfileBlog() {
       <h2>ByteBeam and SFDA impurity profile automation</h2>
 
       <p>
-        ByteBeam ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not generic copilots. Three are already in production for <strong>Module 1.3 labelling</strong>:
+        ByteBeam's <Link href="/sfda">SFDA RA agents</Link> ship single-purpose AI tooling for SFDA document work — built around how the customer's team actually operates, not generic copilots. Three are already in production for <strong>Module 1.3 labelling</strong>:
       </p>
 
       <ul>

--- a/client/src/pages/blog/sfda-pharmacovigilance-qppv-requirements.tsx
+++ b/client/src/pages/blog/sfda-pharmacovigilance-qppv-requirements.tsx
@@ -1,0 +1,549 @@
+import { Link } from "wouter";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+import BlogRelatedTools from "@/components/blog/BlogRelatedTools";
+import BlogDiscoveryCallCta from "@/components/blog/BlogDiscoveryCallCta";
+
+const PUBLISHED = "2026-05-07";
+const UPDATED = "2026-05-07";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline:
+      "SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026",
+    description:
+      "What in-house RA/PV teams need to know about SFDA pharmacovigilance: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, Saudi-national rules, and where automation actually helps.",
+    image: "https://bytebeam.co/images/blog/sfda-pharmacovigilance-qppv.jpg",
+    author: {
+      "@type": "Person",
+      name: "Talal Bazerbachi",
+      jobTitle: "Founder, ByteBeam",
+      url: "https://bytebeam.co/about",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: PUBLISHED,
+    dateModified: UPDATED,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id":
+        "https://bytebeam.co/blog/sfda-pharmacovigilance-qppv-requirements",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://bytebeam.co",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://bytebeam.co/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "SFDA Pharmacovigilance & QPPV Requirements",
+        item: "https://bytebeam.co/blog/sfda-pharmacovigilance-qppv-requirements",
+      },
+    ],
+  },
+];
+
+export default function SfdaPharmacovigilanceQppvBlog() {
+  return (
+    <BlogLayout
+      title="SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026"
+      description="What in-house RA/PV teams need to know about SFDA pharmacovigilance: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, Saudi-national rules, and where automation actually helps."
+      keywords="SFDA pharmacovigilance, QPPV Saudi Arabia, GVP guideline SFDA, pharmacovigilance Saudi requirements, PSSF SFDA, Saudi Vigilance, ICSR SFDA, PSUR SFDA, RMP SFDA, deputy QPPV Saudi"
+      canonical="https://bytebeam.co/blog/sfda-pharmacovigilance-qppv-requirements"
+      structuredData={structuredData}
+      category="Regulatory"
+      industry="Pharma"
+      readTime="14 min"
+      date={PUBLISHED}
+      updated={UPDATED}
+      author="Talal Bazerbachi"
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        For an in-house pharmacovigilance team, the workload after registration looks nothing like the workload before it. <strong>SFDA pharmacovigilance</strong> obligations are perpetual, multi-stream, and highly document-heavy: every adverse-event case, every PSUR cycle, every RMP version, every audit pull. Get the foundation right and a small team can run a large portfolio. Get it wrong and the same team chases compliance for years.
+      </p>
+
+      <p>
+        This guide is written for Heads of RA, QPPVs, and PV Managers running PV inside the marketing-authorisation holder — not for consultancies. It covers what the SFDA Good Pharmacovigilance Practices (GVP) guideline actually requires, where the Saudi-national rules diverge from EU practice, and where document-heavy work is a candidate for automation versus where it shouldn't be.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "The SFDA's Saudi Vigilance program (NPSC), established in 2009, is the primary recipient of all post-marketing safety data — every MAH must integrate with it.",
+          "The local QPPV must be a Saudi national, full-time, residing in KSA, licensed by the Saudi Commission for Health Specialties (SCFHS); the deputy QPPV must also be a Saudi national.",
+          "The Pharmacovigilance Sub-System File (PSSF) is the local KSA equivalent of the EU PSMF — its content and the QPPV's access to safety data must remain inside KSA.",
+          "ICSR, PSUR/PBRER, and RMP cycles are the highest-recurring document workloads; ICH E2D, E2C(R2), and E2E define the structural expectations.",
+          "Submission of Risk Minimisation Measures (RMMs) and proof of their efficacy is increasingly requested by SFDA — RMP is no longer a write-once document.",
+        ]}
+      />
+
+      <h2>What is SFDA pharmacovigilance?</h2>
+
+      <p>
+        Pharmacovigilance under the Saudi Food and Drug Authority is governed by the <strong>Guideline on Good Pharmacovigilance Practices (GVP)</strong>, document reference <em>DS-G-008</em>, currently in version 3.x. The GVP is structured to mirror EMA GVP modules — covering quality systems, the pharmacovigilance system master file equivalent, signal management, RMPs, ICSRs, PSURs, additional monitoring, and post-authorisation safety studies — but with KSA-specific divergences that an EU-trained team often misses.<sup><a href="#ref1">[1]</a></sup>
+      </p>
+
+      <p>
+        At the centre of the system is the <strong>Saudi Vigilance program</strong>, run by the National Pharmacovigilance and Drug Safety Center (NPSC). Saudi Vigilance was established in 2009 and serves as the receiving authority for all post-marketing safety data from MAHs operating in the Kingdom — adverse event reports, periodic reports, signals, and risk-management documentation.<sup><a href="#ref2">[2]</a></sup> Every marketing authorisation issued by SFDA is conditional on continued PV compliance against the GVP, and inspections against the GVP are now an established part of the SFDA inspection programme.<sup><a href="#ref3">[3]</a></sup>
+      </p>
+
+      <p>
+        Two cross-cutting principles shape every other PV obligation:
+      </p>
+
+      <ol>
+        <li><strong>Local responsibility cannot be delegated globally.</strong> A multinational MAH cannot run KSA pharmacovigilance entirely from a regional or global hub. The SFDA requires a local PV sub-system, a local QPPV, and a locally-resident system file.<sup><a href="#ref1">[1]</a></sup></li>
+        <li><strong>Documentation must be inspection-ready.</strong> The GVP and SFDA inspection practice align on the principle that PV obligations are evidenced through documents — case files, PSSF, RMP, signal reports, audit logs. If it isn't written down with retained evidence, it didn't happen.</li>
+      </ol>
+
+      <h2>QPPV and the Saudi-national requirement</h2>
+
+      <p>
+        The single biggest divergence from the EU model: <strong>the QPPV — and the deputy QPPV — must be Saudi nationals</strong>. This is the rule that catches foreign MAHs entering KSA off-guard, because the EU equivalent has no nationality restriction.<sup><a href="#ref4">[4]</a></sup>
+      </p>
+
+      <p>The SFDA's GVP states the local QPPV must:<sup><a href="#ref1">[1]</a><sup><a href="#ref5">[5]</a></sup></sup></p>
+
+      <ul>
+        <li>Be a Saudi national residing in KSA on a full-time basis</li>
+        <li>Hold a pharmacy or medicine qualification, licensed by the Saudi Commission for Health Specialties (SCFHS)</li>
+        <li>Have demonstrable experience or access to expertise in medicine, pharmaceutical science, epidemiology, and biostatistics</li>
+        <li>Be permanently and continuously available to SFDA — including for unannounced inspections</li>
+        <li>Have authority over the local PV system, including signing off on the PSSF and acting as the single point of contact with Saudi Vigilance</li>
+      </ul>
+
+      <p>
+        The same Saudi-national requirement applies to the <strong>deputy QPPV</strong>, who serves as the formal backup. The deputy must also reside in KSA. This is critical for inspection readiness: SFDA expects either the QPPV or the deputy to be reachable at any time.
+      </p>
+
+      <p>
+        Outsourcing is permitted but constrained. The SFDA GVP allows partial or complete outsourcing of PV activities — including the QPPV role — to a local Saudi PV service provider, but the QPPV / LQPPV themselves must still be physically located in Saudi Arabia.<sup><a href="#ref4">[4]</a></sup> In practice, the choice for an MAH is typically: hire a Saudi pharmacist QPPV in-house, contract with a Saudi PV consultancy that supplies one, or partner with the local affiliate's existing PV staff.
+      </p>
+
+      <p>
+        For in-house teams, <strong>continuity is the operational risk</strong>. A QPPV resignation creates an immediate gap — and the deputy is not always trained to step in fully. Maintaining tested handover documentation, role-and-responsibilities matrices, and an up-to-date PSSF section on QPPV scope is the difference between a 30-day rebuild and a regulatory finding.
+      </p>
+
+      <h2>Core PV obligations after registration</h2>
+
+      <p>
+        Once a product is registered, six PV streams run continuously. Each one consumes time differently, and each one has specific document deliverables that consume team capacity in predictable ways.
+      </p>
+
+      <h3>Individual Case Safety Reports (ICSRs)</h3>
+
+      <p>
+        ICSRs are the unit of safety reporting. Every credible adverse event observed in a Saudi patient — whether reported by a healthcare professional, a consumer, or pulled from literature — must be documented as an ICSR and submitted to Saudi Vigilance within prescribed timelines. <strong>ICH E2D</strong> defines the structural standard for post-approval safety data collection that the SFDA GVP follows: serious adverse reactions are reported on an expedited 15-calendar-day clock, while non-serious cases follow periodic reporting.<sup><a href="#ref6">[6]</a></sup>
+      </p>
+
+      <p>
+        For an in-house team, the ICSR workload scales linearly with the marketed portfolio and with patient volume. Manual triage — duplicate detection, seriousness classification, causality assessment, MedDRA coding, narrative drafting — is where most PV operational time accumulates. Multinational MAHs often run global ICSR processing in their parent system, then have the Saudi QPPV review and submit locally; the SFDA expects local oversight of every Saudi case regardless of the global system.<sup><a href="#ref7">[7]</a></sup>
+      </p>
+
+      <h3>Periodic Safety Update Reports (PSUR / PBRER)</h3>
+
+      <p>
+        The PSUR is the cornerstone of periodic benefit-risk reporting. <strong>ICH E2C(R2)</strong> renamed and restructured the format as the Periodic Benefit-Risk Evaluation Report (PBRER) to shift emphasis from adverse-event tabulation to integrated benefit-risk assessment.<sup><a href="#ref8">[8]</a></sup> The SFDA GVP follows the E2C(R2) PBRER structure for periodic reports.
+      </p>
+
+      <p>
+        PSUR cycles are predictable but expensive. A typical PSUR consumes 3–6 weeks of senior PV time per product per cycle. The bulk of that effort is mechanical: aggregating ICSRs, summarising trial data, pulling literature, regenerating signal evaluations, and formatting tables to ICH structure. The judgmental part — the integrated benefit-risk discussion — is a fraction of the actual time. This imbalance is what makes PSUR cycles a strong automation candidate.
+      </p>
+
+      <h3>Risk Management Plan (RMP) and Risk Minimisation Measures (RMMs)</h3>
+
+      <p>
+        The RMP is the strategic safety document for each product. <strong>ICH E2E</strong> defines the pharmacovigilance planning framework — the safety specification, pharmacovigilance plan, and risk minimisation activities.<sup><a href="#ref9">[9]</a></sup> The SFDA GVP requires an RMP for new authorisations and significant variations, and the document is expected to evolve over the product's lifecycle.
+      </p>
+
+      <p>
+        Recent SFDA practice has put more weight on <strong>RMM efficacy evidence</strong>. SFDA increasingly requests proof that risk-minimisation measures (educational materials, controlled distribution, prescriber checklists) are actually being delivered and used, not just documented in the RMP.<sup><a href="#ref10">[10]</a></sup> This shifts the RMP from a write-once document to a living artefact with periodic updates and evidence packs.
+      </p>
+
+      <h3>Pharmacovigilance Sub-System File (PSSF)</h3>
+
+      <p>
+        The PSSF is the KSA-specific document that describes the MAH's local pharmacovigilance system — equivalent in spirit to the EU PSMF, but anchored in Saudi territory. The SFDA requires the PSSF content and QPPV-accessible safety data to remain inside KSA: multinational MAHs may keep their global database abroad, but the QPPV must have local access to Saudi case data, or alternatively maintain a local database in Saudi Arabia.<sup><a href="#ref11">[11]</a></sup>
+      </p>
+
+      <p>The PSSF must describe:</p>
+      <ul>
+        <li>The Saudi QPPV's qualifications, role, and reporting line</li>
+        <li>Computerised systems and databases used at national level</li>
+        <li>Procedures for collecting, processing, and reporting safety data — including timeframes, parties, flow diagrams, and any third parties involved</li>
+        <li>Quality system documentation and training records</li>
+        <li>Contingency arrangements for QPPV unavailability</li>
+      </ul>
+
+      <p>
+        A frequently-missed compliance point: the PSSF is supposed to be <strong>kept current</strong>, not refreshed only at inspection. Each material change to the PV system (new product, new third party, new database, QPPV change) requires a PSSF update with version control.
+      </p>
+
+      <h3>Signal management and literature monitoring</h3>
+
+      <p>
+        Signal management is the proactive arm of PV — detecting emerging safety patterns from the cumulative case data and from external sources. Literature monitoring is the structured weekly/monthly search of medical literature for adverse-event mentions of marketed products. Both are time-intensive and both produce documentation that must be retained for inspection.<sup><a href="#ref12">[12]</a></sup>
+      </p>
+
+      <h3>Audit and inspection readiness</h3>
+
+      <p>
+        SFDA conducts both routine and triggered PV inspections. The inspection scope typically covers QPPV qualifications and continuity, PSSF accuracy versus actual practice, ICSR processing timelines, PSUR submission compliance, RMP/RMM execution, signal-management documentation, training records, and CAPA history.<sup><a href="#ref3">[3]</a></sup> Inspection readiness is not a one-week project; it is a continuous documentation discipline that the QPPV owns.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="PV"
+        variant="inline"
+        eyebrow="Bytebeam · Discovery call"
+        headline="Map your PV workload — find the work that's a candidate for automation"
+        body="If your team handles ICSR triage, PSUR drafting, RMP maintenance, or PSSF upkeep recurringly, walk us through it in a 30-minute call. We'll show you which document touchpoints we'd automate first, and what stays with the QPPV."
+        ctaLabel="Book a 30-min PV scoping call"
+        showProofOfPattern={false}
+      />
+
+      <h2>Why PV obligations eat senior team time</h2>
+
+      <p>
+        Across the in-house teams we work with, PV time consumption follows a consistent pattern. The judgmental work — causality assessment, integrated benefit-risk discussions, signal-strength evaluation — is a small fraction. The bulk is structured document work that scales with portfolio size:
+      </p>
+
+      <ul>
+        <li><strong>ICSR triage</strong> grows linearly with marketed products and Saudi patient volume. Senior PV time spent on case-level review (not data entry, but actual review) is non-trivial — and goes up sharply when literature monitoring or social-media sources are added.</li>
+        <li><strong>PSUR preparation</strong> consumes 3–6 weeks per product per cycle. Most of that is data aggregation and section drafting in the ICH E2C(R2) format. The benefit-risk synthesis at the end is fast in comparison.</li>
+        <li><strong>RMP maintenance</strong> is no longer write-once. Variations, labelling changes, and SFDA RMM-efficacy requests trigger updates that ripple through prescriber materials and distribution evidence packs.<sup><a href="#ref10">[10]</a></sup></li>
+        <li><strong>PSSF currency</strong> is a perpetual maintenance task. Most non-compliance findings here are version-control failures — the document doesn't reflect actual practice because the practice changed and the document didn't.</li>
+        <li><strong>Inspection readiness</strong> means pulling evidence on demand. Without a structured retention system, inspection prep is a fire drill where the QPPV reconstructs months of activity from email threads and shared drives.</li>
+      </ul>
+
+      <p>
+        The Arab pharmacovigilance literature consistently identifies <strong>capacity and resource constraints</strong> as one of the biggest barriers to PV maturity in the region — not lack of regulation but lack of bandwidth to operationalise it.<sup><a href="#ref7">[7]</a></sup> For a small in-house team with a growing portfolio, the work compounds faster than headcount can be justified.
+      </p>
+
+      <h2>Benefits of automating recurring PV document work</h2>
+
+      <p>
+        AI agents purpose-built for SFDA PV work do not replace the QPPV — they replace the structured drafting and aggregation work that scales with portfolio size. Four measurable benefits for an in-house team:
+      </p>
+
+      <ol>
+        <li><strong>ICSR throughput.</strong> Case-level triage assistance — duplicate detection, seriousness classification, MedDRA term suggestions, narrative drafting from structured fields — frees senior reviewers for actual judgment calls.</li>
+        <li><strong>Faster PSUR cycles.</strong> Aggregation of ICSRs, line listings, literature pulls, and section drafting in E2C(R2) format moves from weeks to days. The QPPV still owns the integrated benefit-risk discussion.</li>
+        <li><strong>RMP version control + RMM evidence packs.</strong> Auto-generated diff reports against the previous RMP version. Structured retention of RMM delivery evidence (educational material distribution logs, prescriber acknowledgements) tied to the RMP version that triggered them.</li>
+        <li><strong>PSSF auto-currency.</strong> Section-level updates triggered by changes elsewhere in the PV system (new product, new third party, QPPV change) — no more annual catch-up rewrites.</li>
+      </ol>
+
+      <p>
+        The output stays editable. The QPPV signs off in normal review tools, then submits via Saudi Vigilance. Audit trails are retained automatically — inspection readiness becomes a side effect of doing the work, not a separate project.
+      </p>
+
+      <h2>How to choose an SFDA PV automation partner</h2>
+
+      <p>
+        The market for "AI for pharmacovigilance" is noisy. Most generic offerings are built around EU/US PV practice and miss the SFDA-specific points that define KSA compliance. When evaluating, look for:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th>Why it matters for SFDA PV</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>SFDA GVP-aligned outputs</strong></td>
+            <td>Generic ICH-style outputs miss KSA-specific structure. Verify with sample output before licensing.</td>
+          </tr>
+          <tr>
+            <td><strong>Saudi-national QPPV workflow support</strong></td>
+            <td>Tools that assume the QPPV is in EU/US miss the QPPV-resides-in-KSA control points (PSSF locality, sign-off authority).</td>
+          </tr>
+          <tr>
+            <td><strong>ICH E2D, E2C(R2), E2E compliance</strong></td>
+            <td>The structural standards are not optional. Outputs must follow the format SFDA expects.</td>
+          </tr>
+          <tr>
+            <td><strong>Audit trail retention by default</strong></td>
+            <td>SFDA inspections are evidence-driven. Every run retained, every change versioned.</td>
+          </tr>
+          <tr>
+            <td><strong>Editable structured output</strong></td>
+            <td>QPPV review happens in Word/Excel. Locked-PDF output is a non-starter.</td>
+          </tr>
+          <tr>
+            <td><strong>Process-led scoping</strong></td>
+            <td>Your team's SOPs are the ground truth, not a vendor's template. The right partner co-builds.</td>
+          </tr>
+          <tr>
+            <td><strong>Free first-run preview</strong></td>
+            <td>Verify output quality on your own data before any commercial conversation.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The last two points separate SFDA-specialised partners from generic PV vendors. Generic vendors lead with template demos. Specialised partners ask to walk through your SOPs first.
+      </p>
+
+      <BlogRelatedPosts
+        slugs={[
+          "sfda-variations-type-ia-ib-ii-decision-guide",
+          "sfda-drug-registration-guide-saudi-arabia",
+          "no-code-document-automation-regulatory-teams-2026",
+        ]}
+        heading="Related reading for RA / PV teams"
+        subtitle="Adjacent topics if you're scaling a Saudi PV operation."
+      />
+
+      <h2>ByteBeam and SFDA PV automation</h2>
+
+      <p>
+        ByteBeam ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not a generic copilot. Three are already in production for SFDA <strong>Module 1.3 labelling</strong>:
+      </p>
+
+      <ul>
+        <li><Link href="/sfda/spc-pil-generator"><strong>SmPC &amp; PIL Generator</strong></Link> — produces Module 1.3-aligned drafts from an originator pack</li>
+        <li><Link href="/sfda/spc-pil-arabic-translator"><strong>Arabic SmPC &amp; PIL Translator</strong></Link> — regulator-recognised Arabic with RTL formatting</li>
+        <li><Link href="/sfda/dossier-gap-analysis"><strong>Dossier Gap Analysis</strong></Link> — pre-submission completeness sweep against Module 1.3 + GCC labelling guidance</li>
+      </ul>
+
+      <p>
+        Pharmacovigilance is the next workload we're scoping with customer teams. ICSR triage, PSUR drafting, RMP version control, and PSSF currency are all candidates — but the right shape of each agent depends on how your team's SOPs actually run today. That's why we don't ship a generic PV copilot. We scope the work with you, then build the agent for your process.
+      </p>
+
+      <h2>The future of PV in SFDA-regulated submissions</h2>
+
+      <p>
+        Three shifts are reshaping how PV teams operate inside the SFDA ecosystem:
+      </p>
+
+      <h3>Single-purpose agents over general copilots</h3>
+
+      <p>
+        The wave of "general AI for pharma" is giving way to agents scoped to specific PV tasks. ICSR triage, PSUR drafting, and signal documentation each have distinct quality bars and distinct data flows — they don't share an interface. Expect more purpose-built tooling and less generic copilot framing.
+      </p>
+
+      <h3>RMM evidence is becoming first-class</h3>
+
+      <p>
+        SFDA's increased attention on RMM efficacy evidence pushes the RMP from a strategy document toward an operational artefact with continuous evidence collection.<sup><a href="#ref10">[10]</a></sup> Expect tooling that treats RMM materials, distribution logs, and HCP acknowledgements as structured, versioned, queryable evidence — not unstructured PDFs in a shared drive.
+      </p>
+
+      <h3>Pre-emptive signal detection moves left</h3>
+
+      <p>
+        Aggregated case data + literature monitoring + post-marketing study data are deterministic enough that AI can surface candidate signals earlier. Final signal-strength evaluation remains with the QPPV, but the detection step is increasingly automated. Saudi Vigilance's data-sharing posture suggests the regulator is moving in the same direction.<sup><a href="#ref2">[2]</a></sup>
+      </p>
+
+      <h3>Saudi-national requirements aren't going away</h3>
+
+      <p>
+        Automation is not a substitute for the local QPPV. The Saudi-national rule reflects regulatory and Saudisation policy, not a technology gap. The right way to think about AI in SFDA PV is as <strong>QPPV leverage</strong>: the same QPPV runs a larger portfolio without the document workload scaling proportionally.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="PV"
+        eyebrow="Bytebeam · PV scoping call"
+        headline="Scope your PV automation with your team's process — not a generic template"
+        body="Walk us through how your team currently handles ICSR triage, PSUR drafting, RMP maintenance, or PSSF upkeep. In 30 minutes we'll map the document touchpoints we'd automate first, and you leave with a written scoping summary you can take back to your QPPV / Head of RA."
+        ctaLabel="Book a 30-min PV scoping call"
+        expectations={[
+          "You walk us through your PSUR / ICSR / RMP / PSSF workflow as it runs today",
+          "We map the document touchpoints we'd automate first, and what stays with the QPPV",
+          "You leave with a written scoping summary — no commitment, no template demos",
+        ]}
+      />
+
+      <h2>Conclusion</h2>
+
+      <p>
+        SFDA pharmacovigilance is an inherently document-heavy discipline operating under Saudi-specific rules — the QPPV must be Saudi national, the PSSF must be locally accessible, RMM evidence is increasingly scrutinised, and inspection readiness is a continuous documentation discipline. For an in-house PV team, the strategic question is not <em>whether</em> to invest in PV infrastructure but <em>where to invest first</em>: the QPPV/deputy continuity, the PSSF, the ICSR/PSUR/RMP cycle, and the audit-readiness layer all compete for finite senior time.
+      </p>
+
+      <p>
+        Automation is not a substitute for regulatory judgment, and it does not absolve the Saudi QPPV of accountability. What it does is change the ratio of structured document work to judgmental work — letting the same team run a much larger portfolio without proportionally scaling headcount. The right starting point is whatever recurring document workload is currently consuming the most senior time in your specific operation.
+      </p>
+
+      <BlogRelatedTools
+        eyebrow="Try the SFDA toolkit"
+        heading="The 3 SFDA tools we've already shipped"
+        subtitle="Module 1.3 labelling agents — proof of pattern for the work we co-build with in-house teams. Free first run on each, audit-trailed, DOCX out."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+
+      <ol className="text-sm">
+        <li id="ref1">
+          <a
+            href="https://sfda.gov.sa/en/regulations/79225"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — Guideline on Good Pharmacovigilance Practices (GVP), DS-G-008
+          </a>{" "}
+          (current version on the official SFDA regulations portal).
+        </li>
+        <li id="ref2">
+          Alshammari T.M. et al.{" "}
+          <a
+            href="https://www.sciencedirect.com/science/article/pii/S131901641830001X"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Saudi Vigilance Program: Challenges and lessons learned
+          </a>
+          . Saudi Pharmaceutical Journal, ScienceDirect.
+        </li>
+        <li id="ref3">
+          <a
+            href="https://www.sfda.gov.sa/sites/default/files/2023-03/AnnualReport2022PVInspection.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA Pharmacovigilance Inspections Annual Report (Jan 1 – Dec 31,
+            2022)
+          </a>{" "}
+          — official SFDA inspection findings.
+        </li>
+        <li id="ref4">
+          Alshammari T.M. et al.{" "}
+          <a
+            href="https://link.springer.com/article/10.1007/s40264-019-00807-4"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Pharmacovigilance Systems in Arab Countries: Overview of 22 Arab
+            Countries
+          </a>
+          . Drug Safety, Springer Nature.
+        </li>
+        <li id="ref5">
+          <a
+            href="https://istitlaa.ncc.gov.sa/en/health/sfda/GVP/Pages/Article_001.aspx"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA GVP — Module I: Pharmacovigilance Systems and Their Quality
+            System
+          </a>{" "}
+          (public consultation portal).
+        </li>
+        <li id="ref6">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/E2D_Guideline.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            E2D Post-Approval Safety Data Management
+          </a>
+          . International Council for Harmonisation, Step 4.
+        </li>
+        <li id="ref7">
+          Alshammari T.M. et al. (Drug Safety, 2019).{" "}
+          <a
+            href="https://link.springer.com/article/10.1007/s40264-019-00807-4"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Pharmacovigilance Systems in Arab Countries
+          </a>
+          {" "}— capacity and resource constraints in regional PV practice.
+        </li>
+        <li id="ref8">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/E2C_R2_Guideline.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            E2C(R2) Periodic Benefit-Risk Evaluation Report (PBRER)
+          </a>
+          . International Council for Harmonisation, Step 4.
+        </li>
+        <li id="ref9">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/E2E_Guideline.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            E2E Pharmacovigilance Planning
+          </a>
+          . International Council for Harmonisation, Step 4.
+        </li>
+        <li id="ref10">
+          <a
+            href="https://www.mavenrs.com/blog/SFDA-Pharmacovigilance-in-Saudi-Arabia-2025-Building-Modern-Compliant-and-Market-Ready-Drug-Safety-Systems"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA practice update on Risk Minimisation Measures (RMM) efficacy
+            evidence
+          </a>
+          {" "}— industry analysis of recent SFDA expectations.
+        </li>
+        <li id="ref11">
+          <a
+            href="https://istitlaa.ncc.gov.sa/en/health/sfda/GVP/Pages/default.aspx"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA GVP — Pharmacovigilance Sub-System File (PSSF) requirements
+          </a>{" "}
+          (public consultation index).
+        </li>
+        <li id="ref12">
+          <a
+            href="https://www.moh.gov.sa/eServices/Licences/Documents/91.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            DS-G-008-V3.1 SFDA GVP Guideline — Signal management and literature
+            monitoring (PDF)
+          </a>
+          .
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: May 2026. Saudi Vigilance procedures and SFDA GVP
+          interpretations evolve frequently — verify current expectations
+          against the official SFDA regulations portal at{" "}
+          <a
+            href="https://sfda.gov.sa/en"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            sfda.gov.sa
+          </a>{" "}
+          before finalising submissions.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/sfda-pharmacovigilance-qppv-requirements.tsx
+++ b/client/src/pages/blog/sfda-pharmacovigilance-qppv-requirements.tsx
@@ -15,7 +15,7 @@ const structuredData = [
     headline:
       "SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026",
     description:
-      "What in-house RA/PV teams need to know about SFDA pharmacovigilance: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, Saudi-national rules, and where automation actually helps.",
+      "SFDA pharmacovigilance for in-house RA/PV teams: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, and where automation actually helps in 2026.",
     image: "https://bytebeam.co/images/blog/sfda-pharmacovigilance-qppv.jpg",
     author: {
       "@type": "Person",
@@ -69,7 +69,7 @@ export default function SfdaPharmacovigilanceQppvBlog() {
   return (
     <BlogLayout
       title="SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026"
-      description="What in-house RA/PV teams need to know about SFDA pharmacovigilance: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, Saudi-national rules, and where automation actually helps."
+      description="SFDA pharmacovigilance for in-house RA/PV teams: QPPV qualifications, PSSF, ICSR/PSUR/RMP cycles, and where automation actually helps in 2026."
       keywords="SFDA pharmacovigilance, QPPV Saudi Arabia, GVP guideline SFDA, pharmacovigilance Saudi requirements, PSSF SFDA, Saudi Vigilance, ICSR SFDA, PSUR SFDA, RMP SFDA, deputy QPPV Saudi"
       canonical="https://bytebeam.co/blog/sfda-pharmacovigilance-qppv-requirements"
       structuredData={structuredData}
@@ -319,7 +319,7 @@ export default function SfdaPharmacovigilanceQppvBlog() {
       <h2>ByteBeam and SFDA PV automation</h2>
 
       <p>
-        ByteBeam ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not a generic copilot. Three are already in production for SFDA <strong>Module 1.3 labelling</strong>:
+        The <Link href="/sfda">ByteBeam SFDA toolkit</Link> ships single-purpose AI agents for SFDA document work — built around how the customer's team actually operates, not a generic copilot. Three are already in production for SFDA <strong>Module 1.3 labelling</strong>:
       </p>
 
       <ul>

--- a/client/src/pages/blog/sfda-variations-type-ia-ib-ii-decision-guide.tsx
+++ b/client/src/pages/blog/sfda-variations-type-ia-ib-ii-decision-guide.tsx
@@ -1,0 +1,525 @@
+import { Link } from "wouter";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+import BlogRelatedTools from "@/components/blog/BlogRelatedTools";
+import BlogDiscoveryCallCta from "@/components/blog/BlogDiscoveryCallCta";
+
+const PUBLISHED = "2026-05-07";
+const UPDATED = "2026-05-07";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline:
+      "SFDA Variations Decision Guide: Type IA, IB, II — A Practical Reference for In-House RA Teams",
+    description:
+      "How SFDA classifies post-approval variations under Guidelines v6.3, when to use Type IA / IA(IN) / IB / II, and where the work is automatable.",
+    image: "https://bytebeam.co/images/blog/sfda-variations-decision-guide.jpg",
+    author: {
+      "@type": "Person",
+      name: "Talal Bazerbachi",
+      jobTitle: "Founder, ByteBeam",
+      url: "https://bytebeam.co/about",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: PUBLISHED,
+    dateModified: UPDATED,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id":
+        "https://bytebeam.co/blog/sfda-variations-type-ia-ib-ii-decision-guide",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://bytebeam.co",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: "https://bytebeam.co/blog",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "SFDA Variations Decision Guide",
+        item: "https://bytebeam.co/blog/sfda-variations-type-ia-ib-ii-decision-guide",
+      },
+    ],
+  },
+];
+
+export default function SfdaVariationsBlog() {
+  return (
+    <BlogLayout
+      title="SFDA Variations Decision Guide: Type IA, IB, II — A Practical Reference for In-House RA Teams"
+      description="How SFDA classifies post-approval variations under Guidelines v6.3, when to use Type IA / IA(IN) / IB / II, and where the work is automatable."
+      keywords="SFDA variations, Type IA Type IB Type II SFDA, SFDA variation guidelines v6.3, SFDA variation classification, post-approval changes Saudi Arabia, drug variation submission KSA, SFDA do and tell, GCC variation guidelines"
+      canonical="https://bytebeam.co/blog/sfda-variations-type-ia-ib-ii-decision-guide"
+      structuredData={structuredData}
+      category="Regulatory"
+      industry="Pharma"
+      readTime="14 min"
+      date={PUBLISHED}
+      updated={UPDATED}
+      author="Talal Bazerbachi"
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        For any marketed pharmaceutical product, change is inevitable — a manufacturing site moves, a specification tightens, a label gets revised, a pack size gets added. Every one of those changes is a <strong>variation</strong>, and every variation needs to be classified, documented, and submitted to SFDA in the right format on the right clock. Variations are the highest-frequency document workload in marketed-product regulatory affairs — and the place where in-house teams most often lose time to administrative overhead.
+      </p>
+
+      <p>
+        This guide is written for in-house RA professionals managing lifecycle changes inside the marketing-authorisation holder. It walks through how the SFDA Variation Guidelines (currently v6.3, with v6.4 framework updates issued in 2024) classify post-approval changes, which documentation each type requires, the timelines and procedural windows that catch teams out, and where the work is — and isn't — a candidate for automation.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "SFDA classifies variations into Type IA, IA(IN), IB, and Type II — risk-based tiers that map closely to the EU framework under Regulation (EC) 1234/2008.",
+          "Type IA is 'Do and Tell' (implement first, notify later); Type IB is 'Tell, Wait, and Do' (notify, wait through review, then implement); Type II requires prior approval.",
+          "Type IA(IN), introduced in SFDA Guidelines v6.1, is the immediate-notification subtype — submit within 14 days of implementation; other Type IAs can be batched in an annual report by 31 January.",
+          "The latest SFDA Variation Guidelines (v6.3) sit alongside the SFDA Variation Classification Guidance — the classification decision is the single most error-prone step.",
+          "GCC harmonisation under the GCC Variation Guidelines makes most KSA classifications recognisable across UAE, Bahrain, Oman, Kuwait, and Qatar, but national divergences remain.",
+        ]}
+      />
+
+      <h2>What is a variation under SFDA?</h2>
+
+      <p>
+        A variation is any change to the terms of a marketing authorisation after it has been granted. In practice that covers a very wide span: an administrative change of MAH name, a quality change in the drug substance synthesis, the addition of a new pack size, a change in the manufacturing site, a labelling update, a new clinical indication. Each of these triggers a variation submission to the SFDA — and the regulator's job is to confirm that the change does not undermine the quality, safety, or efficacy on which the original authorisation was granted.<sup><a href="#ref1">[1]</a></sup>
+      </p>
+
+      <p>
+        SFDA documents the rules in two complementary publications. The <strong>Variation Guidelines</strong> (currently <em>006-G-DS Requirements Version 6.3</em>) describe the procedure: how to classify, what to submit, the windows for implementation and review, and the fee structure.<sup><a href="#ref1">[1]</a></sup> The <strong>Variation Classification Guidance</strong> (SFDAVPC) is the lookup table — change types organised by area (administrative, quality/CMC, safety, efficacy, labelling) with the type assigned to each.<sup><a href="#ref2">[2]</a></sup> An in-house RA team uses both: the classification guidance to decide the type, the procedural guidelines to drive the workflow.
+      </p>
+
+      <p>
+        SFDA's framework is closely modelled on the EU variations system established under Commission Regulation (EC) No 1234/2008 (as amended by Regulation (EU) No 712/2012). The four-tier classification — Type IA, IA(IN), IB, II — and the procedural philosophy are recognisable to anyone trained on EMA practice.<sup><a href="#ref3">[3]</a></sup> What differs is the local procedural specifics: SFDA fees, SFDA timelines, eSDR submission mechanics, and the SFDA-specific Module 1.3 labelling expectations that propagate into many variation types.
+      </p>
+
+      <h2>The four-tier classification</h2>
+
+      <p>
+        Every SFDA variation falls into one of four types, in increasing order of risk and procedural weight.
+      </p>
+
+      <h3>Type IA — Minor, "Do and Tell"</h3>
+
+      <p>
+        Type IA covers changes with <strong>minimal or no impact</strong> on the quality, safety, or efficacy of the product. The MAH may implement the change first and notify SFDA after the fact. Examples: change of MAH address, change of approved storage condition wording, removal of a duplicate manufacturer, an editorial typo correction.<sup><a href="#ref4">[4]</a></sup>
+      </p>
+
+      <p>
+        Standard Type IA variations can be compiled into a <strong>single annual variation report</strong> submitted to SFDA no later than <strong>31 January</strong> of the following year. This is the procedural relief that recognises low-risk changes shouldn't generate one submission per change.
+      </p>
+
+      <h3>Type IA(IN) — Minor, immediate notification</h3>
+
+      <p>
+        SFDA Guidelines v6.1 introduced a new subtype between IA and IB: <strong>Type IA(IN)</strong>, the immediate-notification variant. These are still minor variations, but the regulator wants to be informed promptly rather than waiting for the annual report. Type IA(IN) submissions must be made <strong>within 14 days following implementation</strong>.<sup><a href="#ref4">[4]</a></sup>
+      </p>
+
+      <p>
+        This subtype caught many in-house teams off-guard when introduced — what previously batched into an annual roll-up now requires a stand-alone submission with its own clock. Reading the latest classification guidance carefully matters; assumptions from older versions are a common source of late filings.
+      </p>
+
+      <h3>Type IB — Minor, "Tell, Wait, and Do"</h3>
+
+      <p>
+        Type IB sits in the middle: changes with <strong>limited but non-minimal impact</strong> on quality, safety, or efficacy. The MAH must <strong>notify SFDA before implementation</strong>, then wait through the review window — historically 30 days under EU practice — to confirm the regulator does not object before implementing the change.<sup><a href="#ref5">[5]</a></sup>
+      </p>
+
+      <p>
+        The "Tell, Wait, and Do" mechanic is procedurally lightweight but operationally important. Implementation cannot proceed during the wait window; if SFDA raises a question, the clock resets. Teams treating Type IB as effectively a Type IA — implementing before the wait clears — risk findings at the next inspection.
+      </p>
+
+      <h3>Type II — Major, prior approval required</h3>
+
+      <p>
+        Type II covers <strong>major changes</strong> with significant potential impact on quality, safety, or efficacy. These require <strong>full SFDA prior approval before implementation</strong>. Examples include a new indication, a change in dosage form, a major manufacturing process change, addition of a strength, or a significant change to the safety section of the SmPC.<sup><a href="#ref4">[4]</a></sup>
+      </p>
+
+      <p>
+        Type II submissions follow the full assessment workflow — administrative validation, scientific assessment, possible RFI cycles — with timelines analogous to a partial registration review. The documentation pack scales accordingly: data justifying the change, updated quality / clinical / non-clinical sections as relevant, updated Module 1.3 labelling artefacts, and supporting evidence.
+      </p>
+
+      <h2>Documentation expectations per type</h2>
+
+      <p>
+        The single most consequential decision in any variation is the classification. Get it wrong upward (over-class) and you spend months waiting for prior approval the change didn't require. Get it wrong downward (under-class) and you implement a major change without authorisation — a finding category in any inspection. The SFDA Variation Classification Guidance is the lookup that drives this; the classification table runs to dozens of pages and is updated with each guideline revision.<sup><a href="#ref2">[2]</a></sup>
+      </p>
+
+      <p>
+        Documentation expectations scale with the classification:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Procedure</th>
+            <th>Typical documentation</th>
+            <th>Implementation timing</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Type IA</strong></td>
+            <td>Do and Tell</td>
+            <td>Cover letter, application form, supporting documents per classification entry, updated CTD sections affected</td>
+            <td>Implement first; notify in annual report by 31 Jan</td>
+          </tr>
+          <tr>
+            <td><strong>Type IA(IN)</strong></td>
+            <td>Do and Tell, immediate</td>
+            <td>Same as IA</td>
+            <td>Implement first; notify within 14 days</td>
+          </tr>
+          <tr>
+            <td><strong>Type IB</strong></td>
+            <td>Tell, Wait, and Do</td>
+            <td>Cover letter, application form, justification, supporting data per classification entry, updated CTD sections, updated SmPC/PIL where applicable</td>
+            <td>Notify; wait through review window; then implement</td>
+          </tr>
+          <tr>
+            <td><strong>Type II</strong></td>
+            <td>Prior approval</td>
+            <td>Full justification dossier, expert reports, updated Module 2 summaries, updated quality/clinical/non-clinical modules, updated Module 1.3 labelling artefacts, RMP update if applicable</td>
+            <td>Cannot implement until SFDA approval</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        Across all four types, the consistent layer is <strong>Module 1.3 labelling impact</strong>. Most variations propagate to the SmPC, PIL, or labelling — even an apparently administrative change can require the Arabic PIL to be re-translated and SFDA-aligned. This is where labelling automation tools become directly relevant to variation throughput.
+      </p>
+
+      <p>
+        For broader context on how variations fit into the overall SFDA registration ecosystem, see our <Link href="/blog/sfda-drug-registration-guide-saudi-arabia">SFDA Drug Registration Guide</Link>.
+      </p>
+
+      <h2>GCC harmonisation: where it helps and where it doesn't</h2>
+
+      <p>
+        The GCC Drug Registration framework includes a <strong>GCC Variation Guidelines</strong> document (currently v6.2) that harmonises classification across the seven Gulf states.<sup><a href="#ref6">[6]</a></sup> In principle, a Type II classification under GCC rules is a Type II in KSA, UAE, Oman, Bahrain, Kuwait, and Qatar — the same documentation pack supports submissions across the bloc.<sup><a href="#ref7">[7]</a></sup>
+      </p>
+
+      <p>
+        In practice, harmonisation reduces but does not eliminate per-country work. National divergences remain in: language requirements (Arabic mandates differ in stringency), local administrative documents (agent licences, fee structures), and local procedural deadlines. For an MAH with a regional portfolio, the GCC framework is a major efficiency win — but the team still maintains country-specific variation tracking. The GCC Centralised Procedure compresses some of that further but is not used for all variation types.<sup><a href="#ref7">[7]</a></sup>
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="variations"
+        variant="inline"
+        headline="Map your variation throughput — see what we'd automate first"
+        body="If your team handles 5+ variations per month across a marketed portfolio, walk us through your current process. We'll identify where AI agents can compress the document assembly cycle and which steps stay with the QPPV / RA lead."
+        ctaLabel="Book a 30-min variations scoping call"
+        showProofOfPattern={false}
+      />
+
+      <h2>Why variations eat senior RA time</h2>
+
+      <p>
+        Across the in-house teams we work with, variation throughput is the single biggest predictor of how much senior RA time gets consumed by recurring administrative work. The reason is structural — not strategic.
+      </p>
+
+      <ul>
+        <li><strong>Classification decisions compound.</strong> Each variation begins with reading the SFDA Classification Guidance against the proposed change. Easy ones (address change → Type IA) take minutes; ambiguous ones (a manufacturing change spanning two classification entries) can consume hours of RA time and cross-functional discussion.</li>
+        <li><strong>Documentation packs are mostly mechanical.</strong> Once classified, the variation pack assembly is largely structural: cover letter, application form, classification justification, the specific supporting documents required by the classification entry, updated CTD sections in eCTD format, and (very often) updated Module 1.3 labelling artefacts in both English and Arabic. The judgmental work — what changed and why — is a fraction of the time spent.</li>
+        <li><strong>Module 1.3 labelling propagates everywhere.</strong> A surprising share of variations affect labelling. Adding a strength → new SmPC sections + new PIL + new Arabic translations. A safety variation → SmPC update + PIL update + Arabic update + RMM material refresh. The labelling ripple effect is what makes variation cycles longer than the underlying technical change suggests.</li>
+        <li><strong>Annual roll-up overhead.</strong> The 31 January Type IA roll-up is its own mini-project — gathering all year's IA changes, organising them, generating one consolidated submission. Teams underestimate this until the second January.</li>
+        <li><strong>Tracking across portfolio + GCC scale.</strong> An MAH with a 40-SKU portfolio across 5 GCC countries handles hundreds of variations per year. Maintaining the cross-country variation tracker, the classification decisions per country, and the implementation timing windows is itself a non-trivial operational task.</li>
+      </ul>
+
+      <p>
+        This pattern — high volume, mostly structural document work, with a smaller judgment layer on top — is exactly the shape that AI agents purpose-built for the workflow can compress dramatically. Generic copilots don't understand the SFDA classification table; specialised agents do.
+      </p>
+
+      <h2>Benefits of automating variation pack assembly</h2>
+
+      <p>
+        Variation automation does not replace the RA professional — it compresses the document-heavy half of the work so the team can run a larger portfolio without proportional headcount. Four measurable benefits:
+      </p>
+
+      <ol>
+        <li><strong>Classification assistance.</strong> An agent that takes the proposed change as input and proposes a classification (with the matching SFDA Classification Guidance entry as evidence) cuts the per-variation classification step from hours to minutes — and surfaces the borderline cases for senior review explicitly.</li>
+        <li><strong>Pack assembly automation.</strong> Cover letter, application form, classification justification, supporting documents from approved templates, updated CTD sections — all auto-generated from the change description and the affected dossier sections. RA reviews and signs off rather than typing.</li>
+        <li><strong>Module 1.3 labelling propagation.</strong> Variations that touch labelling can hand off directly to the existing SFDA labelling agents (<Link href="/sfda/spc-pil-generator">SmPC + PIL Generator</Link>, <Link href="/sfda/spc-pil-arabic-translator">Arabic Translator</Link>, <Link href="/sfda/dossier-gap-analysis">Gap Analysis</Link>) rather than restarting labelling work in Word.</li>
+        <li><strong>Annual roll-up automation.</strong> The Type IA annual report compiles itself from the year's batched IA decisions. The team reviews and signs off rather than reconstructing twelve months of changes from emails.</li>
+      </ol>
+
+      <p>
+        Critically, every automation step retains an audit trail. SFDA inspections can and do request evidence trails for variation classifications and submissions; structured retention turns inspection prep from a fire drill into a side-effect of the normal workflow.
+      </p>
+
+      <h2>How to choose a variation automation partner</h2>
+
+      <p>
+        Generic "regulatory document AI" offerings rarely understand variation work. The classification table is SFDA-specific; the eCTD section mapping is jurisdictional; the labelling propagation requires Saudi-Arabic capability. When evaluating partners:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th>Why it matters</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>SFDA Classification Guidance coverage</strong></td>
+            <td>The agent must reason against the actual SFDA classification table, with citations to the entry that drives each suggestion. Not a generic LLM hallucination layer.</td>
+          </tr>
+          <tr>
+            <td><strong>SFDA Variation Guidelines version awareness</strong></td>
+            <td>v6.3 differs from v6.1 in subtle ways (Type IA(IN) is the obvious one). Tool must track current version, not freeze on training data.</td>
+          </tr>
+          <tr>
+            <td><strong>eCTD section mapping</strong></td>
+            <td>Updated CTD sections in eCTD format — automation that doesn't speak eCTD adds work, doesn't remove it.</td>
+          </tr>
+          <tr>
+            <td><strong>Module 1.3 labelling integration</strong></td>
+            <td>Variations propagate to labelling. Tools that hand off to SFDA-specific labelling agents save the second-pass rework.</td>
+          </tr>
+          <tr>
+            <td><strong>Audit trail retention</strong></td>
+            <td>Classification decisions, supporting evidence, version history — every step retained for inspection. Default behaviour, not a checkbox.</td>
+          </tr>
+          <tr>
+            <td><strong>Process-led scoping</strong></td>
+            <td>Your SOPs are the ground truth. Generic templates lose to agents co-built around your team's actual variation workflow.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <BlogRelatedPosts
+        slugs={[
+          "sfda-drug-registration-guide-saudi-arabia",
+          "sfda-pharmacovigilance-qppv-requirements",
+          "no-code-document-automation-regulatory-teams-2026",
+        ]}
+        heading="Related reading for in-house RA teams"
+        subtitle="Adjacent topics if you're scaling marketed-product RA across a SFDA portfolio."
+      />
+
+      <h2>ByteBeam and SFDA variation automation</h2>
+
+      <p>
+        ByteBeam's <Link href="/sfda">SFDA Module 1.3 agents</Link> ship single-purpose tooling for SFDA document work. Three are already in production for <strong>Module 1.3 labelling</strong>:
+      </p>
+
+      <ul>
+        <li><Link href="/sfda/spc-pil-generator"><strong>SmPC &amp; PIL Generator</strong></Link> — produces Module 1.3-aligned drafts from the originator pack</li>
+        <li><Link href="/sfda/spc-pil-arabic-translator"><strong>Arabic SmPC &amp; PIL Translator</strong></Link> — regulator-recognised Arabic with RTL formatting</li>
+        <li><Link href="/sfda/dossier-gap-analysis"><strong>Dossier Gap Analysis</strong></Link> — pre-submission completeness sweep against Module 1.3 + GCC labelling guidance</li>
+      </ul>
+
+      <p>
+        Variation pack assembly is one of the workloads we're actively scoping with customer teams. The right shape of a variation agent depends on your team's existing classification decisions, your eCTD authoring environment, and how much of the labelling work has already been moved into the existing SFDA tools. That's why we don't ship a generic variation copilot — we scope each agent to fit how the customer's RA team actually runs.
+      </p>
+
+      <h2>The future of variation management</h2>
+
+      <p>
+        Two shifts are reshaping how SFDA variations are handled in regulated markets — both worth tracking even if your team isn't ready to act on them yet.
+      </p>
+
+      <h3>ICH Q12 and lifecycle management</h3>
+
+      <p>
+        <strong>ICH Q12</strong> introduced the concept of <em>Established Conditions</em> — the legally binding parts of the dossier where any change requires a variation, separated from supportive information that doesn't.<sup><a href="#ref8">[8]</a></sup> Combined with Post-Approval Change Management Protocols (PACMPs), Q12 is intended to reduce the variation overhead for well-controlled CMC changes by pre-agreeing the change-management framework at registration.
+      </p>
+
+      <p>
+        SFDA's posture on Q12 has been evolving. As Q12 implementation matures globally, expect SFDA practice to follow the broader trend toward risk-based reporting categories — meaning fewer Type IIs for changes covered by an approved PACMP, and more attention to defining Established Conditions clearly at registration.
+      </p>
+
+      <h3>Stronger GCC harmonisation pressure</h3>
+
+      <p>
+        The PMC literature on GCC harmonisation consistently identifies post-approval changes as one of the highest-value targets for further alignment.<sup><a href="#ref7">[7]</a></sup> The GCC Variation Guidelines v6.2 already harmonised much of the classification framework; future revisions are likely to reduce remaining country-by-country divergences.
+      </p>
+
+      <h3>Automation moves left in the workflow</h3>
+
+      <p>
+        The biggest practical shift isn't a regulatory change — it's where AI gets applied in the variation lifecycle. Three years ago, "AI for variations" mostly meant document classification at the end. Today, agents are increasingly used at the front of the workflow: helping the RA team classify the change, propose the documentation set, and pre-populate the pack from existing dossier sections. The QPPV / RA lead becomes the reviewer rather than the typist.
+      </p>
+
+      <BlogDiscoveryCallCta
+        topic="variations"
+        eyebrow="Bytebeam · Variations scoping call"
+        headline="Scope your variation pack assembly with your team's process — not a generic template"
+        body="Walk us through how your team currently classifies, drafts, and tracks variations across your SFDA portfolio. In 30 minutes we'll map the document touchpoints we'd automate first, and what stays with the QPPV / RA lead."
+        ctaLabel="Book a 30-min variations scoping call"
+        expectations={[
+          "You walk us through your variation classification + pack assembly workflow as it runs today",
+          "We identify where AI agents would compress the cycle (and where they wouldn't)",
+          "You leave with a written scoping summary — no commitment, no template demos",
+        ]}
+      />
+
+      <h2>Conclusion</h2>
+
+      <p>
+        SFDA variations are the highest-frequency document workload in marketed-product RA. The classification framework is risk-based and recognisable to anyone trained on EU practice, but the SFDA-specific procedural details (Type IA(IN) deadlines, annual report mechanics, Module 1.3 labelling propagation) catch teams out repeatedly. Most of the per-variation time is structural document work, not regulatory judgment — which is exactly why purpose-built AI agents compress the cycle so well when they're scoped properly.
+      </p>
+
+      <p>
+        For an in-house RA team running a 40-SKU portfolio across the GCC, the question isn't whether variation automation is justified — the volume settles that. The question is which agent shape fits your team's existing classification practice, eCTD authoring environment, and labelling workflow. That's a co-build decision, not a vendor selection.
+      </p>
+
+      <BlogRelatedTools
+        eyebrow="Try the SFDA toolkit"
+        heading="The SFDA tools we've already shipped"
+        subtitle="Module 1.3 labelling agents — proof of pattern for the variation labelling propagation we co-build with in-house teams. Free first run on each, audit-trailed, DOCX out."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+
+      <ol className="text-sm">
+        <li id="ref1">
+          <a
+            href="https://www.sfda.gov.sa/sites/default/files/2025-03/Variation_0.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — 006-G-DS Requirements Version 6.3, Variation Guidelines
+          </a>{" "}
+          (official SFDA publication, March 2025).
+        </li>
+        <li id="ref2">
+          <a
+            href="https://www.sfda.gov.sa/sites/default/files/2023-11/SFDAVPC-E.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — Variation Classification Guidance (SFDAVPC)
+          </a>{" "}
+          (official SFDA publication, November 2023).
+        </li>
+        <li id="ref3">
+          <a
+            href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52013XC0802(04)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            European Commission — Guidelines on the details of the various
+            categories of variations (2013/C 223/01) under Regulation (EC) No
+            1234/2008
+          </a>
+          .
+        </li>
+        <li id="ref4">
+          <a
+            href="https://istitlaa.ncc.gov.sa/en/health/sfda/VariationRequirements/Pages/default.aspx"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            SFDA — Guidelines for Variation Requirements (public consultation
+            portal)
+          </a>
+          .
+        </li>
+        <li id="ref5">
+          EMA —{" "}
+          <a
+            href="https://www.ema.europa.eu/en/type-ia-variations-questions-answers"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Type-IA variations: questions and answers
+          </a>{" "}
+          and{" "}
+          <a
+            href="https://www.ema.europa.eu/en/human-regulatory-overview/post-authorisation/classification-changes-questions-answers"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Classification of changes: Q&amp;A
+          </a>{" "}
+          — primary EU references that the SFDA framework mirrors.
+        </li>
+        <li id="ref6">
+          <a
+            href="https://moh.gov.om/media/njapgzui/updated-the-gcc-guidelines-for-variation-requirements-version-62-%D8%A7%D9%84%D8%AF%D9%84%D9%8A%D9%84-%D8%A7%D9%84%D8%A5%D8%B1%D8%B4%D8%A7%D8%AF%D9%8A-%D9%84%D9%84%D8%AA%D8%BA%D9%8A%D8%B1%D8%A7%D8%AA.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GCC — Guidelines for Variation Requirements (Version 6.2)
+          </a>{" "}
+          (Oman Ministry of Health mirror).
+        </li>
+        <li id="ref7">
+          Hashan H. et al.{" "}
+          <a
+            href="https://pmc.ncbi.nlm.nih.gov/articles/PMC9334421/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Evaluation of the Performance of the Gulf Cooperation Council
+            Centralised Regulatory Review Process
+          </a>
+          . PMC, 2022 — peer-reviewed analysis of GCC regulatory harmonisation.
+        </li>
+        <li id="ref8">
+          ICH —{" "}
+          <a
+            href="https://database.ich.org/sites/default/files/Q12_Guideline_Step4_2019_1119.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Q12 Technical and Regulatory Considerations for Pharmaceutical
+            Product Lifecycle Management
+          </a>
+          . International Council for Harmonisation, Step 4 (2019).
+        </li>
+        <li id="ref9">
+          <a
+            href="https://www.tamimi.com/news/saudi-food-drug-authority-issues-new-and-updated-guidance-documents-a-q1-q2-2024-update/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Al Tamimi &amp; Company — Saudi Food &amp; Drug Authority Q1 &amp;
+            Q2 2024 Update
+          </a>{" "}
+          (industry analysis of recent SFDA guidance updates).
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: May 2026. SFDA Variation Guidelines and Classification
+          Guidance evolve with each version. Verify current version and
+          classification entry against the official SFDA regulations portal at{" "}
+          <a
+            href="https://sfda.gov.sa/en"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            sfda.gov.sa
+          </a>{" "}
+          before submitting.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/sfda/index.tsx
+++ b/client/src/pages/sfda/index.tsx
@@ -8,6 +8,8 @@ import {
   FileCheck2,
   Sparkles,
   CalendarClock,
+  BookOpen,
+  Calendar,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import Navigation from "@/components/navigation";
@@ -17,6 +19,12 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { BOOK_DEMO_URL, SFDA_TOOLS } from "@/lib/sfda/tools";
+import { getVisiblePosts } from "@/lib/blog/posts";
+
+/** Pharma RA blog cluster surfaced on the SFDA hub for cross-pillar link velocity. */
+const PHARMA_INSIGHTS = getVisiblePosts().filter(
+  (post) => post.category === "Regulatory" && post.industry === "Pharma",
+);
 
 const PAGE_URL = "https://bytebeam.co/sfda";
 
@@ -199,6 +207,73 @@ export default function SfdaHubPage() {
               ))}
             </div>
           </section>
+
+          {/* Pharma RA insights — cluster surface from parent hub to leaf blogs */}
+          {PHARMA_INSIGHTS.length > 0 && (
+            <section className="max-w-5xl mx-auto py-16 border-t">
+              <div className="text-center mb-10">
+                <Badge variant="secondary" className="gap-1.5 mb-3">
+                  <BookOpen className="size-3 text-primary" />
+                  Pharma RA Insights
+                </Badge>
+                <h2 className="text-2xl sm:text-3xl font-bold mb-3">
+                  Deep dives on SFDA submission work
+                </h2>
+                <p className="text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+                  Authoritative guides for in-house RA, PV, and CMC teams —
+                  primary-source cited, framework-aligned, written for
+                  practitioners. Each is a candidate workstream we co-build
+                  agents for.
+                </p>
+              </div>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {PHARMA_INSIGHTS.map((post) => (
+                  <Link
+                    key={post.slug}
+                    href={`/blog/${post.slug}`}
+                    className="group block"
+                  >
+                    <Card className="h-full hover:border-primary/40 hover:shadow-md transition-all">
+                      <CardContent className="p-5 flex flex-col h-full">
+                        <Badge variant="secondary" className="self-start mb-3 text-[10px] uppercase tracking-wider">
+                          {post.category}
+                        </Badge>
+                        <h3 className="font-semibold text-base leading-snug mb-2 group-hover:text-primary transition-colors line-clamp-2">
+                          {post.shortTitle ?? post.title}
+                        </h3>
+                        <p className="text-xs text-muted-foreground leading-relaxed line-clamp-3 flex-1">
+                          {post.description}
+                        </p>
+                        <div className="mt-4 pt-3 border-t flex items-center justify-between text-[11px] text-muted-foreground">
+                          <span className="inline-flex items-center gap-1">
+                            <Calendar className="size-3" />
+                            {new Date(post.date).toLocaleDateString("en-US", {
+                              month: "short",
+                              year: "numeric",
+                            })}
+                          </span>
+                          <span className="inline-flex items-center gap-1.5 font-medium text-foreground group-hover:text-primary transition-colors">
+                            <Clock className="size-3" />
+                            {post.readTime}
+                            <ArrowRight className="size-3 group-hover:translate-x-0.5 transition-transform" />
+                          </span>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+              <div className="mt-8 text-center">
+                <Link
+                  href="/blog"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline underline-offset-4"
+                >
+                  See all pharma insights
+                  <ArrowRight className="size-3.5" />
+                </Link>
+              </div>
+            </section>
+          )}
 
           {/* Final CTA */}
           <section className="max-w-3xl mx-auto py-16 text-center">


### PR DESCRIPTION
## Summary

Builds the SFDA/pharma RA content cluster targeting in-house RA / PV / CMC teams (the platform's ICP — companies with internal RA capability that can co-build automation around their existing process). Each blog is **framework-aligned** (parsli archetype: definition → key takeaways → challenges → benefits → buyer guide → ByteBeam positioning → future → further reading), **2,500+ words**, **primary-source cited** (SFDA official guidance, ICH guidelines, peer-reviewed papers).

This PR is on top of #12 (already merged). It adds 2 commits:
- ` a96a5d4` Add SFDA/pharma RA cluster — 5 blogs + new BlogDiscoveryCallCta + SFDA_BOOKING_URL constant
- ` a816ad2` Framework-alignment audit fixes — meta descriptions, parent-hub wiring, reverse cross-links

## Foundations

- `SFDA_BOOKING_URL` constant in [`lib/sfda/tools.ts`](client/src/lib/sfda/tools.ts) — single source of truth for all SFDA/pharma "Book a discovery call" CTAs. Currently a placeholder Google Calendar URL — **swap for production link in one place** before going live.
- New [`BlogDiscoveryCallCta`](client/src/components/blog/BlogDiscoveryCallCta.tsx) component with topic-specific scoping framing ("Walk us through your [process]. We'll show you what we'd automate first") — designed for blogs where no existing tool maps directly. Inline + panel variants. CTA copy lives in component props for easy A/B iteration.
- All existing Calendly URLs across the codebase repointed via the central constant.

## 5 new blog posts (under category=Regulatory, industry=Pharma)

| Blog | URL | ICP | CTA |
|---|---|---|---|
| **SFDA Pharmacovigilance & QPPV** | `/blog/sfda-pharmacovigilance-qppv-requirements` | In-house RA + PV teams | Scope PV automation |
| **SFDA Variations IA/IB/II** | `/blog/sfda-variations-type-ia-ib-ii-decision-guide` | RA Manager handling lifecycle | Scope variation pack assembly |
| **SFDA eCTD Submission Format** | `/blog/sfda-ectd-submission-module-structure` | RA team running submissions | Funnels into 3 existing Module 1.3 tools |
| **SFDA DMF & Letter of Access** | `/blog/sfda-drug-master-file-letter-of-access` | API mfr RA + finished-product MAH | Scope DMF/LoA workflow |
| **Impurity Profile (ICH Q3 + M7)** | `/blog/sfda-impurity-profile-ich-q3a-q3b-q3d` | Innovator + complex-generic CMC | Scope impurity profile compilation |

Every blog: 2,500+ words, 8–12 primary-source citations, full archetype structure, mid-article inline CTA + end-of-article panel CTA, ≤155 char meta description.

## Cluster wiring (parsli SEO framework)

- **Hub-and-spoke**: `/sfda` hub now has a "Pharma RA Insights" section surfacing all 5 blogs, registry-driven so future blogs auto-appear.
- **Reverse cross-links**: Each of the 3 SFDA tools' "Related reading" `resources` array now points at the new pharma cluster.
- **Cross-pillar density**: Each blog links to ≥3 sibling blogs, ≥2 parent hubs (`/blog` via breadcrumb + `/sfda` via inline body link), and the 3 SFDA tools as proof-of-pattern.
- **Anchor text variation**: Each blog uses a different anchor for the same `/sfda` target (`ByteBeam SFDA toolkit` / `SFDA Module 1.3 agents` / `SFDA labelling toolkit` / `SFDA RA agents`).

## Vercel deployment note

Commit `a96a5d4` triggered a Vercel build failure due to a git-tracking miss on the variations blog file (referenced in App.tsx but not committed). Commit `a816ad2` accidentally `git add`-ed the missing file, fixing the build. **Latest preview deploy on this branch (`dpl_H3iNoqLZtqBQ837BNxwX1uw5SxJS`) is READY.**

## Test plan
- [ ] All 5 blogs render at `/blog/<slug>`
- [ ] Each blog's "Book a 30-min scoping call" CTA opens the SFDA_BOOKING_URL in a new tab
- [ ] Each blog's BlogRelatedPosts cards link to 3 sibling blogs in the cluster
- [ ] Each blog's BlogRelatedTools cards link to the 3 existing SFDA tools
- [ ] `/sfda` hub now shows a "Pharma RA Insights" section with all 5 blog cards
- [ ] Each SFDA tool page's "Related reading" section surfaces the relevant new pharma blogs
- [ ] Blog index `/blog` shows all 5 blogs under the Regulatory category section
- [ ] **Before going live**: replace placeholder `SFDA_BOOKING_URL` in `lib/sfda/tools.ts` with the production Google Calendar URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)