### PR TITLE
Render Navigation on blog pages

### DIFF
--- a/client/src/components/BlogLayout.tsx
+++ b/client/src/components/BlogLayout.tsx
@@ -4,6 +4,7 @@ import { Link } from "wouter";
 import { ArrowLeft, Calendar, Clock, Share2, Linkedin, Twitter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import SEO from "@/components/SEO";
+import Navigation from "@/components/navigation";
 
 interface BlogLayoutProps {
   title: string;
@@ -81,8 +82,10 @@ export default function BlogLayout({
         structuredData={structuredData}
       />
 
+      <Navigation />
+
       {/* Hero Section */}
-      <section className="section-padding gradient-overlay text-white">
+      <section className="section-padding gradient-overlay text-white pt-28">
         <div className="container-custom">
           <motion.div
             ref={heroRef}


### PR DESCRIPTION
## Summary
- Blog pages (e.g. `/blog/sfda-drug-registration-guide-saudi-arabia`) were rendering without the site-wide top nav — the hero went edge-to-edge with the browser chrome
- `BlogLayout` was missing the `<Navigation />` component that every other top-level page uses
- Added `<Navigation />` and `pt-28` on the hero so it isn't hidden behind the fixed nav

## Test plan
- [ ] Open `/blog` and any post (e.g. `/blog/sfda-drug-registration-guide-saudi-arabia`) — top nav is visible and sticky on scroll
- [ ] Nav links still work; mobile menu opens
- [ ] Hero content isn't clipped under the nav at desktop or mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)