### PR TITLE
Redirect /tools/{bank-statement-parser,resume-parser,screenshot-to-text} to parsli.co

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -43,6 +43,21 @@
       "source": "/fmcg-label-compliance",
       "destination": "/industries/fmcg",
       "statusCode": 301
+    },
+    {
+      "source": "/tools/bank-statement-parser",
+      "destination": "https://parsli.co/tools/bank-statement-parser",
+      "statusCode": 301
+    },
+    {
+      "source": "/tools/resume-parser",
+      "destination": "https://parsli.co/tools/resume-parser",
+      "statusCode": 301
+    },
+    {
+      "source": "/tools/screenshot-to-text",
+      "destination": "https://parsli.co/tools/screenshot-to-text",
+      "statusCode": 301
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary
- Adds 3 edge-level 301 redirects in `vercel.json` for tool pages whose intent matches Parsli's document/data extraction positioning.
- Bytebeam pages: `/tools/bank-statement-parser`, `/tools/resume-parser`, `/tools/screenshot-to-text` → corresponding `https://parsli.co/tools/*` pages.
- Other tool pages (`pdf-merger`, `pdf-page-remover`, `w2-generator`, `nda-generator`, `policy-analyzer`) intentionally left in place — they don't align with Parsli's parser positioning and would dilute topical signal.

## Why
- Bytebeam GSC shows these 3 tool pages getting impressions on extraction-intent queries (bank statement / resume / screenshot-to-text).
- Parsli already has 1:1 matching pages, with self-canonical tags and clean 200 responses (verified).
- 301 passes link equity onto Parsli, consolidating ranking signal where the parser positioning lives.

## Test plan
- [ ] After deploy: `curl -sI https://bytebeam.co/tools/bank-statement-parser` returns `301` + `location: https://parsli.co/tools/bank-statement-parser`
- [ ] Same check for `/tools/resume-parser` and `/tools/screenshot-to-text`
- [ ] Single hop only — no chain
- [ ] Confirm other `/tools/*` paths (`/tools/pdf-merger`, etc.) are unaffected and still resolve on bytebeam.co

🤖 Generated with [Claude Code](https://claude.com/claude-code)