### PR TITLE
Add QuickBooks data-entry blog cluster + blog TOC

### DIFF
--- a/client/public/feed.xml
+++ b/client/public/feed.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://bytebeam.co/feed.xml" rel="self" type="application/rss+xml" />
     <description>AI agents for SFDA pharma regulatory work — SmPC and PIL generation, Arabic translation, dossier gap analysis — plus authoritative guides for in-house RA, PV, and CMC teams.</description>
     <language>en-US</language>
-    <lastBuildDate>Thu, 08 May 2026 00:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 01 Jun 2026 00:00:00 GMT</lastBuildDate>
     <generator>ByteBeam</generator>
 
     <!-- SFDA Tools -->
@@ -30,6 +30,35 @@
       <guid isPermaLink="true">https://bytebeam.co/sfda/dossier-gap-analysis</guid>
       <description>Pre-submission gap analysis for SFDA SmPC and PIL packs. Catches labelling, translation, and section-completeness gaps. Severity-ranked report.</description>
       <category>SFDA Tools</category>
+    </item>
+
+    <!-- QuickBooks data-entry automation — newest first -->
+    <item>
+      <title>How to Import Bank Statements &amp; Transactions into QuickBooks (2026)</title>
+      <link>https://bytebeam.co/blog/import-bank-statements-into-quickbooks</link>
+      <guid isPermaLink="true">https://bytebeam.co/blog/import-bank-statements-into-quickbooks</guid>
+      <description>Every way to get bank statements and transactions into QuickBooks Online and Desktop — bank feeds, the exact CSV/QBO format, and how to convert a PDF statement QuickBooks won't accept.</description>
+      <author>Talal Bazerbachi</author>
+      <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+      <category>Document Automation</category>
+    </item>
+    <item>
+      <title>How to Scan Receipts into QuickBooks (2026): Online, Desktop &amp; Automated</title>
+      <link>https://bytebeam.co/blog/scan-receipts-into-quickbooks</link>
+      <guid isPermaLink="true">https://bytebeam.co/blog/scan-receipts-into-quickbooks</guid>
+      <description>How to scan receipts into QuickBooks Online with Receipt Capture, the mobile app, or email — what it captures, what it misses, and the faster options when it falls short.</description>
+      <author>Talal Bazerbachi</author>
+      <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+      <category>Document Automation</category>
+    </item>
+    <item>
+      <title>How to Import Invoices &amp; Bills into QuickBooks (2026)</title>
+      <link>https://bytebeam.co/blog/import-invoices-bills-into-quickbooks</link>
+      <guid isPermaLink="true">https://bytebeam.co/blog/import-invoices-bills-into-quickbooks</guid>
+      <description>Sales invoices vs vendor bills, and every way to get each into QuickBooks Online and Desktop — Import Data, bill capture OCR, the US bulk-bill limitation, and faster options for scanning vendor invoices.</description>
+      <author>Talal Bazerbachi</author>
+      <pubDate>Mon, 01 Jun 2026 00:00:00 GMT</pubDate>
+      <category>Document Automation</category>
     </item>
 
     <!-- Pharma RA Insights — newest first -->

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -417,6 +417,27 @@
 
   <!-- Blog Articles -->
   <url>
+    <loc>https://bytebeam.co/blog/import-bank-statements-into-quickbooks</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/scan-receipts-into-quickbooks</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://bytebeam.co/blog/import-invoices-bills-into-quickbooks</loc>
+    <lastmod>2026-06-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://bytebeam.co/blog/uae-food-labeling-requirements-2026</loc>
     <lastmod>2026-03-16</lastmod>
     <changefreq>monthly</changefreq>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -103,6 +103,9 @@ const IDPBusinessGuideBlog = lazy(() => import("@/pages/blog/intelligent-documen
 const InvoiceProcessingBlog = lazy(() => import("@/pages/blog/automating-invoice-processing-2026"));
 const AgenticOCRBlog = lazy(() => import("@/pages/blog/agentic-ocr-intelligent-data-extraction-2026"));
 const ArabicOCRBlog = lazy(() => import("@/pages/blog/arabic-ocr-challenges-solutions-2026"));
+const ImportBankStatementsQuickBooksBlog = lazy(() => import("@/pages/blog/import-bank-statements-into-quickbooks"));
+const ScanReceiptsQuickBooksBlog = lazy(() => import("@/pages/blog/scan-receipts-into-quickbooks"));
+const ImportInvoicesBillsQuickBooksBlog = lazy(() => import("@/pages/blog/import-invoices-bills-into-quickbooks"));
 
 // Loading component for lazy-loaded routes
 function ToolsLoading() {
@@ -202,6 +205,9 @@ function Router() {
         <Route path="/blog/automating-invoice-processing-2026" component={InvoiceProcessingBlog} />
         <Route path="/blog/agentic-ocr-intelligent-data-extraction-2026" component={AgenticOCRBlog} />
         <Route path="/blog/arabic-ocr-challenges-solutions-2026" component={ArabicOCRBlog} />
+        <Route path="/blog/import-bank-statements-into-quickbooks" component={ImportBankStatementsQuickBooksBlog} />
+        <Route path="/blog/scan-receipts-into-quickbooks" component={ScanReceiptsQuickBooksBlog} />
+        <Route path="/blog/import-invoices-bills-into-quickbooks" component={ImportInvoicesBillsQuickBooksBlog} />
 
         {/* Parsli - Document Extraction Platform */}
         <Route path="/parsli/:rest*" component={ParsliApp} />

--- a/client/src/components/BlogLayout.tsx
+++ b/client/src/components/BlogLayout.tsx
@@ -1,10 +1,26 @@
+import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { useInView } from "react-intersection-observer";
 import { Link } from "wouter";
-import { ArrowLeft, Calendar, Clock, Share2, Linkedin, Twitter } from "lucide-react";
+import { ArrowLeft, ArrowRight, Calendar, Clock, Share2, Linkedin, Twitter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import SEO from "@/components/SEO";
 import Navigation from "@/components/navigation";
+import BlogToc, { type TocItem } from "@/components/BlogToc";
+
+interface SidebarCta {
+  heading: string;
+  buttonText: string;
+  href: string;
+  note?: string;
+}
+
+const DEFAULT_SIDEBAR_CTA: SidebarCta = {
+  heading: "Drowning in compliance paperwork?",
+  buttonText: "Book a demo",
+  href: "https://calendly.com/talal-bytebeam/bytebeam-discovery-call",
+  note: "30-min call · no commitment",
+};
 
 interface BlogLayoutProps {
   title: string;
@@ -21,7 +37,18 @@ interface BlogLayoutProps {
   /** ISO date string. When set, shown as "Updated <date>" next to the published date. */
   updated?: string;
   author: string;
+  /** Optional override for the sticky right-rail CTA. */
+  sidebarCta?: SidebarCta;
   children: React.ReactNode;
+}
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
 }
 
 export default function BlogLayout({
@@ -38,12 +65,38 @@ export default function BlogLayout({
   date,
   updated,
   author,
+  sidebarCta = DEFAULT_SIDEBAR_CTA,
   children,
 }: BlogLayoutProps) {
   const [heroRef, heroInView] = useInView({
     triggerOnce: true,
     threshold: 0.1,
   });
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [tocItems, setTocItems] = useState<TocItem[]>([]);
+
+  // Derive the table of contents from the rendered h2 headings, assigning a
+  // stable slug id to each so the TOC anchors and scroll-spy can target them.
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const seen = new Set<string>();
+    const items = Array.from(el.querySelectorAll("h2"))
+      .filter((h) => !h.closest(".not-prose"))
+      .map((h) => {
+      const text = (h.textContent ?? "").trim();
+      let id = h.id || slugify(text);
+      while (id && seen.has(id)) id = `${id}-1`;
+      if (id) {
+        seen.add(id);
+        h.id = id;
+        h.style.scrollMarginTop = "6rem";
+      }
+      return { id, text };
+    });
+    setTocItems(items.filter((i) => i.id && i.text));
+  }, [children]);
 
   const getCategoryColor = (cat: string) => {
     switch (cat) {
@@ -144,8 +197,18 @@ export default function BlogLayout({
       {/* Content Section */}
       <section className="section-padding bg-background">
         <div className="container-custom">
-          <div className="max-w-4xl mx-auto">
+          <div className="mx-auto max-w-4xl lg:max-w-5xl xl:max-w-[1200px] lg:grid lg:grid-cols-[minmax(0,1fr)_290px] lg:gap-x-10 xl:grid-cols-[230px_minmax(0,1fr)_290px] xl:gap-x-12">
+            {/* Left rail: table of contents (xl and up) */}
+            <aside className="hidden xl:block">
+              <div className="sticky top-24">
+                <BlogToc items={tocItems} />
+              </div>
+            </aside>
+
+            {/* Main column */}
+            <div className="min-w-0">
             <motion.div
+              ref={contentRef}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.2 }}
@@ -202,6 +265,33 @@ export default function BlogLayout({
                 </div>
               </div>
             </motion.div>
+            </div>
+
+            {/* Right rail: sticky CTA (lg and up). TOC nests here below xl. */}
+            <aside className="hidden lg:block">
+              <div className="sticky top-24 space-y-6">
+                <div className="xl:hidden">
+                  <BlogToc items={tocItems} />
+                </div>
+                <div className="rounded-2xl border border-primary/20 bg-primary/5 p-6 text-center">
+                  <p className="text-lg font-bold leading-snug mb-5 text-foreground">
+                    {sidebarCta.heading}
+                  </p>
+                  <Button
+                    onClick={() => window.open(sidebarCta.href, "_blank")}
+                    className="w-full h-12 rounded-full bg-primary text-primary-foreground text-base"
+                  >
+                    {sidebarCta.buttonText}
+                    <ArrowRight className="w-4 h-4 ml-1" />
+                  </Button>
+                  {sidebarCta.note && (
+                    <p className="text-xs text-muted-foreground mt-3 mb-0">
+                      {sidebarCta.note}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </aside>
           </div>
         </div>
       </section>

--- a/client/src/components/BlogToc.tsx
+++ b/client/src/components/BlogToc.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+export type TocItem = { id: string; text: string };
+
+export default function BlogToc({ items }: { items: TocItem[] }) {
+  const [activeId, setActiveId] = useState<string | null>(items[0]?.id ?? null);
+
+  useEffect(() => {
+    if (items.length === 0) return;
+
+    const elements = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (elements.length === 0) return;
+
+    // Track which sections intersect the top of the viewport; the topmost
+    // visible one wins. Falls back to the nearest heading above the scroll
+    // position when nothing is intersecting.
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.add(entry.target.id);
+          else visible.delete(entry.target.id);
+        }
+        if (visible.size > 0) {
+          const topmost = items.find((i) => visible.has(i.id));
+          if (topmost) setActiveId(topmost.id);
+          return;
+        }
+        const offset = 120;
+        let candidate: string | null = null;
+        for (const el of elements) {
+          if (el.getBoundingClientRect().top - offset <= 0) candidate = el.id;
+          else break;
+        }
+        if (candidate) setActiveId(candidate);
+      },
+      { rootMargin: "-96px 0px -55% 0px", threshold: [0, 1] },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [items]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <nav aria-label="On this page">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+        On this page
+      </p>
+      <ul className="border-l-2 border-border list-none pl-0 m-0 space-y-0">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <li key={item.id} className="m-0 p-0">
+              <a
+                href={`#${item.id}`}
+                onClick={() => setActiveId(item.id)}
+                className={
+                  "block py-1.5 pl-4 -ml-0.5 text-sm leading-snug border-l-2 no-underline transition-colors " +
+                  (isActive
+                    ? "text-primary font-medium border-primary"
+                    : "text-muted-foreground border-transparent hover:text-foreground hover:border-muted-foreground/50")
+                }
+              >
+                {item.text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/client/src/lib/blog/posts.ts
+++ b/client/src/lib/blog/posts.ts
@@ -39,6 +39,44 @@ export interface BlogPostMeta {
 
 export const BLOG_POSTS: BlogPostMeta[] = [
   {
+    slug: "import-bank-statements-into-quickbooks",
+    title:
+      "How to Import Bank Statements & Transactions into QuickBooks (2026)",
+    shortTitle: "Import Bank Statements into QuickBooks",
+    description:
+      "Every way to get bank statements and transactions into QuickBooks Online and Desktop — bank feeds, the exact CSV/QBO format, and how to convert a PDF statement QuickBooks won't accept.",
+    category: "Automation",
+    industry: "Finance",
+    readTime: "13 min",
+    date: "2026-06-01",
+    updated: "2026-06-01",
+  },
+  {
+    slug: "scan-receipts-into-quickbooks",
+    title:
+      "How to Scan Receipts into QuickBooks (2026): Online, Desktop & Automated",
+    shortTitle: "Scan Receipts into QuickBooks",
+    description:
+      "How to scan receipts into QuickBooks Online with Receipt Capture, the mobile app, or email — what it captures, what it misses, and the faster options when it falls short.",
+    category: "Automation",
+    industry: "Finance",
+    readTime: "12 min",
+    date: "2026-06-01",
+    updated: "2026-06-01",
+  },
+  {
+    slug: "import-invoices-bills-into-quickbooks",
+    title: "How to Import Invoices & Bills into QuickBooks (2026)",
+    shortTitle: "Import Invoices & Bills into QuickBooks",
+    description:
+      "Sales invoices vs vendor bills, and every way to get each into QuickBooks Online and Desktop — Import Data, bill capture OCR, the US bulk-bill limitation, and faster options for scanning vendor invoices.",
+    category: "Automation",
+    industry: "Finance",
+    readTime: "13 min",
+    date: "2026-06-01",
+    updated: "2026-06-01",
+  },
+  {
     slug: "sfda-pharmacovigilance-qppv-requirements",
     title:
       "SFDA Pharmacovigilance & QPPV Requirements: A Practical Guide for In-House Teams in 2026",

--- a/client/src/pages/blog/import-bank-statements-into-quickbooks.tsx
+++ b/client/src/pages/blog/import-bank-statements-into-quickbooks.tsx
@@ -1,0 +1,761 @@
+import { Link } from "wouter";
+import { ArrowRight, CalendarClock, CheckCircle2, Sparkles } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+
+const BOOKING_URL =
+  "https://calendly.com/talal-bytebeam/bytebeam-discovery-call";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline:
+      "How to Import Bank Statements & Transactions into QuickBooks (2026)",
+    description:
+      "Every way to get bank statements and transactions into QuickBooks Online and Desktop — bank feeds, the exact CSV/QBO format QuickBooks needs, and how to convert a PDF statement QuickBooks won't accept.",
+    image:
+      "https://bytebeam.co/images/blog/import-bank-statements-into-quickbooks.jpg",
+    author: { "@type": "Organization", name: "ByteBeam Team" },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: "2026-06-01",
+    dateModified: "2026-06-01",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id":
+        "https://bytebeam.co/blog/import-bank-statements-into-quickbooks",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://bytebeam.co" },
+      { "@type": "ListItem", position: 2, name: "Blog", item: "https://bytebeam.co/blog" },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Import Bank Statements into QuickBooks",
+        item: "https://bytebeam.co/blog/import-bank-statements-into-quickbooks",
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Can QuickBooks import a PDF bank statement?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "No. QuickBooks Online accepts CSV, QBO (Web Connect), QFX, and OFX files — not PDF. QuickBooks Desktop uses QBO (Web Connect) or the legacy IIF format. To use a PDF statement, convert it to a CSV or QBO file first, then upload that.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What CSV format does QuickBooks Online need for bank transactions?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Either 3 columns (Date, Description, Amount) or 4 columns (Date, Description, Credit, Debit). The file must be under 350 KB, contain no more than 1,000 transactions, use a header row, and strip out currency symbols and thousands separators (digits, decimal points, and minus signs only).",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How many bank transactions can I import into QuickBooks at once?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "QuickBooks Online accepts up to 1,000 transactions per CSV upload, and the file must be under 350 KB. If your statement is larger, split it into multiple files and upload them one at a time.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I import bank transactions into QuickBooks Desktop?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Download a Web Connect (.QBO) file from your bank and import it through the Bank Feeds Center, where transactions are matched to your register. The legacy IIF format writes directly to the register but requires exact-match account and vendor names, and Intuit no longer recommends it.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Why does my QuickBooks bank CSV import keep failing?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The most common causes are a date format that doesn't match what you selected during mapping, a file over 350 KB, currency symbols or extra columns in the data, or a missing header row. Fix the formatting and re-upload, or use a parser that outputs a QuickBooks-ready CSV automatically.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is the best way to import a scanned or non-standard PDF statement?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Use a document parser with OCR. Tools such as Parsli, Parseur, and Docparser read scanned or unusual PDF layouts and output a clean, QuickBooks-ready CSV. For high volume or statements from many banks, a custom automation that extracts, validates, and posts the data directly is more reliable than manual conversion.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Is it safe to convert bank statements with a third-party tool?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes, provided the tool encrypts your data and holds recognized certifications such as SOC 2, ISO 27001, or GDPR alignment. Check the vendor's security page before uploading financial documents, and prefer tools that let you delete files after processing.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What file types can QuickBooks Online import for bank transactions?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "QuickBooks Online imports CSV, QBO (Web Connect), QFX, and OFX files. PDF is not supported — convert a PDF statement to one of these formats first.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I convert a PDF bank statement to CSV for free?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Use a free online converter or a document parser. A clean, text-based PDF converts in about a minute; scanned or photographed statements need a parser with OCR. Then upload the resulting CSV through Transactions then Bank transactions.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I import a bank statement into QuickBooks from Excel?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Save the Excel sheet as a CSV in the required layout (Date, Description, Amount, or Date, Description, Credit, Debit), keep it under 350 KB and 1,000 rows, then upload it like any other CSV file.",
+        },
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: "How to import bank transactions into QuickBooks Online with a CSV file",
+    description:
+      "Upload a CSV bank statement into QuickBooks Online when a live bank feed isn't available.",
+    step: [
+      {
+        "@type": "HowToStep",
+        name: "Open Bank transactions",
+        text: "Go to Transactions, then Bank transactions.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Choose Upload from file",
+        text: "Select the account, then choose Upload from file.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Add your file",
+        text: "Drag in your CSV or QBO file and pick the QuickBooks account to import into.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Map columns and import",
+        text: "Map your columns to Date, Description, and Amount, set the date format to match your file, and import.",
+      },
+    ],
+  },
+];
+
+export default function ImportBankStatementsQuickBooksBlog() {
+  return (
+    <BlogLayout
+      title="How to Import Bank Statements & Transactions into QuickBooks (2026)"
+      description="Every way to get bank statements and transactions into QuickBooks Online and Desktop — bank feeds, the exact CSV/QBO format QuickBooks needs, and how to convert a PDF statement QuickBooks won't accept."
+      keywords="import bank statements into quickbooks, import bank transactions into quickbooks online, upload bank statements to quickbooks online, convert pdf bank statement to quickbooks, quickbooks csv import format, bank statement to csv quickbooks, import bank transactions into quickbooks desktop"
+      canonical="https://bytebeam.co/blog/import-bank-statements-into-quickbooks"
+      structuredData={structuredData}
+      category="Automation"
+      industry="Finance"
+      readTime="13 min"
+      date="2026-06-01"
+      author="ByteBeam Team"
+      sidebarCta={{
+        heading: "Bank statements piling up faster than you can key them?",
+        buttonText: "Book a scoping call",
+        href: BOOKING_URL,
+        note: "30-min call · no commitment",
+      }}
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        Getting a bank statement into QuickBooks should take seconds. In
+        practice, people lose <strong>15 to 30 minutes per statement</strong>{" "}
+        retyping rows by hand — and a single transposed digit can derail a
+        reconciliation for hours. The most common reason: QuickBooks{" "}
+        <strong>won't accept a PDF</strong>, which is exactly the format most
+        banks hand you.
+      </p>
+
+      <p>
+        <strong>Quick answer:</strong> QuickBooks Online imports bank
+        transactions from <strong>CSV, QBO, QFX, and OFX</strong> files — not
+        PDF. If your bank connects, use a bank feed; otherwise upload a CSV laid
+        out as <strong>Date, Description, Amount</strong> (or Date, Description,
+        Credit, Debit), kept under 350 KB and 1,000 transactions. To use a PDF
+        statement, convert it to CSV first. QuickBooks Desktop uses a Web
+        Connect (.QBO) file or the legacy .IIF format.
+      </p>
+
+      <p>
+        This guide covers every working method to import bank statements and
+        transactions into QuickBooks — Online and Desktop — in the order most
+        people should try them. You'll get the exact file formats QuickBooks
+        requires, how to convert a PDF statement it refuses to read, and what to
+        do when manual import stops scaling.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "QuickBooks Online imports CSV, QBO, QFX, and OFX files — never PDF. To use a PDF statement you must convert it to CSV or QBO first.",
+          "A manual CSV must follow an exact shape: 3 columns (Date, Description, Amount) or 4 (Date, Description, Credit, Debit), under 350 KB, max 1,000 transactions.",
+          "QuickBooks Desktop uses Web Connect (.QBO) files through the Bank Feeds Center, or the legacy .IIF format Intuit no longer recommends.",
+          "For scanned or non-standard PDFs, a document parser with OCR turns the statement into a QuickBooks-ready CSV automatically.",
+          "At high volume or across multiple banks, a custom automation that extracts, validates, and posts data beats any manual conversion.",
+        ]}
+      />
+
+      <h2>The methods at a glance</h2>
+
+      <p>
+        Five methods get bank data into QuickBooks. Which one fits depends on
+        whether your bank connects directly, what file you have, and how often
+        you do this.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Best for</th>
+            <th>What you get</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Bank feed (auto-connect)</td>
+            <td>Ongoing entry from a supported bank</td>
+            <td>Transactions flow in daily, automatically</td>
+          </tr>
+          <tr>
+            <td>Manual CSV / QBO upload</td>
+            <td>One-off imports, or banks that don't connect</td>
+            <td>Transactions from a file you provide</td>
+          </tr>
+          <tr>
+            <td>Convert a PDF statement</td>
+            <td>When all you have is a PDF</td>
+            <td>A QuickBooks-ready CSV to upload</td>
+          </tr>
+          <tr>
+            <td>Document parser (SaaS)</td>
+            <td>Scanned or messy PDFs, regular volume</td>
+            <td>Automated PDF-to-CSV with OCR</td>
+          </tr>
+          <tr>
+            <td>Custom automation</td>
+            <td>Many banks, high volume, reconciliation</td>
+            <td>Hands-off, end-to-end into QuickBooks</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Method 1: Connect a bank feed (the default)</h2>
+
+      <p>
+        If your bank is supported, a live bank feed is the cleanest option.
+        QuickBooks pulls new transactions automatically, so there's no file to
+        format and nothing to retype.
+      </p>
+
+      <p>
+        In QuickBooks Online, go to <strong>Transactions &rarr; Bank
+        transactions</strong>, select <strong>Link account</strong>, search for
+        your bank, and authenticate. QuickBooks imports recent history (commonly
+        the last 90 days, sometimes more) and then keeps syncing. New
+        transactions land in the <strong>For review</strong> tab, where you
+        confirm the category and match them to existing records.
+      </p>
+
+      <p>
+        <strong>Where bank feeds fall short:</strong> not every bank or credit
+        union is supported, the connection can only reach back so far, and
+        closed accounts, foreign banks, and older history simply aren't
+        available through the feed. When the feed can't help, you move to a file
+        import.
+      </p>
+
+      <h2>Method 2: Upload a CSV or QBO file (QuickBooks Online)</h2>
+
+      <p>
+        When the feed isn't an option, you can upload a file by hand. QuickBooks
+        Online accepts <strong>CSV, QBO (Web Connect), QFX, and OFX</strong>.
+        Many banks let you download one of these directly — always check for a
+        CSV or QBO export before doing anything manual.
+      </p>
+
+      <p>To upload:</p>
+      <ol>
+        <li>
+          Go to <strong>Transactions &rarr; Bank transactions</strong>.
+        </li>
+        <li>
+          Select the account, then choose <strong>Upload from file</strong> (or
+          the drop-down arrow next to <strong>Link account</strong>).
+        </li>
+        <li>Drag in your file and pick the QuickBooks account to import into.</li>
+        <li>
+          Map your columns to QuickBooks fields (Date, Description, Amount), set
+          the date format to match your file, and import.
+        </li>
+      </ol>
+
+      <h3>The exact CSV format QuickBooks Online requires</h3>
+
+      <p>
+        This is where most imports fail. QuickBooks accepts a CSV in one of two
+        shapes:
+      </p>
+      <ul>
+        <li>
+          <strong>3-column:</strong> Date, Description, Amount (one signed
+          amount column — negatives for money out).
+        </li>
+        <li>
+          <strong>4-column:</strong> Date, Description, Credit, Debit (separate
+          columns for money in and money out).
+        </li>
+      </ul>
+
+      <p>And the file rules that trip people up:</p>
+      <ul>
+        <li>First row must be <strong>headers</strong>.</li>
+        <li>
+          File must be <strong>under 350 KB</strong> and contain no more than{" "}
+          <strong>1,000 transactions</strong> — split larger statements into
+          multiple files.
+        </li>
+        <li>
+          Remove <strong>currency symbols and thousands separators</strong>.
+          Cells should contain digits, decimal points, and minus signs only
+          (e.g. <code>-1250.00</code>, not <code>($1,250.00)</code>).
+        </li>
+        <li>Leave zero-amount cells blank rather than entering 0.</li>
+        <li>Use a single, consistent date format and English text.</li>
+      </ul>
+
+      <p>
+        If an import errors out, the usual culprits are a date format that
+        doesn't match your selection, a file over the size cap, stray currency
+        symbols, or a missing header row. Fix the formatting and re-upload.
+      </p>
+
+      <h2>Method 3: Import into QuickBooks Desktop</h2>
+
+      <p>
+        QuickBooks Desktop handles bank data differently. The recommended path is
+        a <strong>Web Connect (.QBO)</strong> file: download it from your bank,
+        then import it through the <strong>Bank Feeds Center</strong>{" "}
+        (<strong>Banking &rarr; Bank Feeds</strong>). Transactions arrive in the
+        center and are matched against your register, much like the Online{" "}
+        <em>For review</em> flow.
+      </p>
+
+      <p>
+        The legacy <strong>.IIF</strong> (Intuit Interchange Format) writes
+        transactions straight into the register, but it's unforgiving: account
+        names, vendors, and other references must match your file exactly, or the
+        import breaks. Intuit no longer recommends IIF for transactions, so reach
+        for it only if you have no other option.
+      </p>
+
+      <h2>The PDF problem: why QuickBooks rejects your statement</h2>
+
+      <p>
+        Here's the wall almost everyone hits: your bank gives you a{" "}
+        <strong>PDF</strong>, and QuickBooks doesn't accept PDFs — not Online,
+        not Desktop. There's no setting to change. QuickBooks needs the data as
+        structured rows (CSV/QBO), and a PDF is just a page layout.
+      </p>
+
+      <p>So you have two real options:</p>
+      <ol>
+        <li>
+          <strong>Get a CSV or QBO from your bank instead.</strong> Many banks
+          offer it under the same download menu as the PDF. Always check here
+          first — it's free and avoids conversion entirely.
+        </li>
+        <li>
+          <strong>Convert the PDF to a QuickBooks-ready CSV.</strong> For a
+          one-off, a free online converter — including our own{" "}
+          <Link href="/tools/bank-statement-parser">bank statement parser</Link>{" "}
+          — can turn a clean, text-based PDF into a CSV in a minute. For scanned
+          statements or anything you do regularly, a dedicated document parser is
+          more reliable (next section).
+        </li>
+      </ol>
+
+      <p>
+        A caution on conversion: text-based PDFs convert cleanly, but{" "}
+        <strong>scanned or photographed statements need OCR</strong>, and
+        multi-page or multi-account statements often confuse simple converters —
+        rows get merged, columns shift, running balances get misread. That's the
+        gap purpose-built parsers fill.
+      </p>
+
+      <h2>Method 4: Convert the PDF with a document parser</h2>
+
+      <p>
+        A document parser reads a bank statement — even a scanned one — and
+        extracts each transaction (date, description, debit, credit, balance)
+        into a clean table you can export as a QuickBooks-ready CSV. No retyping,
+        no manual column-fixing. For teams that process statements every week,
+        this is the sweet spot between manual work and a full custom build.
+      </p>
+
+      <p>
+        Four self-serve tools are worth knowing. They differ most in how they get
+        the data <em>into</em> QuickBooks and how much they cost to start.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Best for</th>
+            <th>Path into QuickBooks</th>
+            <th>Free option</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Parsli</strong></td>
+            <td>Simplest path into QuickBooks; scanned statements</td>
+            <td><strong>Native QuickBooks connector</strong> + QuickBooks-ready CSV</td>
+            <td>100 pages free, no card</td>
+          </tr>
+          <tr>
+            <td>Parseur</td>
+            <td>Forward-to-extract email workflows</td>
+            <td>CSV, or via Zapier</td>
+            <td>20 pages / month</td>
+          </tr>
+          <tr>
+            <td>Docparser</td>
+            <td>Bookkeepers handling many banks</td>
+            <td>Pre-formatted CSV, or via Zapier</td>
+            <td>14-day trial</td>
+          </tr>
+          <tr>
+            <td>Affinda</td>
+            <td>Enterprise volume with validation</td>
+            <td>API-first (Xero / Dynamics named)</td>
+            <td>Free converter + trial</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        <strong>
+          <a href="https://parsli.co/tools/bank-statement-parser" target="_blank" rel="noopener noreferrer">Parsli</a>
+        </strong>{" "}
+        reads PDF and scanned statements with built-in OCR, extracts the full
+        transaction table as line items, and exports a clean, QuickBooks-ready
+        CSV. It's the one tool here with a{" "}
+        <a href="https://parsli.co/integrations/quickbooks" target="_blank" rel="noopener noreferrer">
+          native QuickBooks connector
+        </a>
+        , so for bills and invoices it can post straight into QuickBooks rather
+        than routing through a third-party connector — the others reach
+        QuickBooks via Zapier, a formatted CSV, or their API. It also has the
+        most generous free tier (100 pages, no card), which makes it the lowest-
+        friction option to test against your own statements.
+      </p>
+
+      <p>
+        <strong>
+          <a href="https://parseur.com/use-case/pdf-bank-statement" target="_blank" rel="noopener noreferrer">Parseur</a>
+        </strong>{" "}
+        is built around a forward-to-extract workflow:
+        you email statements to a dedicated address (or upload them) and it
+        returns structured data using OCR and AI, with no parsing rules to build.
+        It exports CSV, Excel, or JSON and reaches QuickBooks through Zapier. A
+        genuinely free tier (20 pages a month) makes it easy to trial for
+        low-volume needs.
+      </p>
+
+      <p>
+        <strong>
+          <a href="https://docparser.com/solutions/bank-statement-data-extraction/" target="_blank" rel="noopener noreferrer">Docparser</a>
+        </strong>{" "}
+        is a mature, accounting-focused parser that
+        turns PDF and scanned statements into spreadsheet-ready data and supports
+        statements from hundreds of banks. It can export a CSV pre-formatted for
+        direct QuickBooks or Xero import, or route parsed transactions through
+        Zapier. Pricing is a 14-day trial then tiered plans from roughly $33 a
+        month — a solid fit for bookkeepers who want a dependable, template-driven
+        path.
+      </p>
+
+      <p>
+        <strong>
+          <a href="https://www.affinda.com/documents/bank-statement/" target="_blank" rel="noopener noreferrer">Affinda</a>
+        </strong>{" "}
+        is an enterprise-grade document-AI platform that
+        combines OCR and large language models to extract and validate statement
+        data in 50+ languages and unusual layouts, including handwriting. It's
+        API-first (its named accounting connectors are Xero and Microsoft
+        Dynamics rather than QuickBooks) and suits higher-volume or
+        compliance-sensitive teams that need validation at scale more than a
+        one-click QuickBooks button.
+      </p>
+
+      <p>
+        One honest caveat across the category: of these, only Parsli ships a
+        native QuickBooks connector. The rest get you to QuickBooks through a
+        formatted CSV import or a Zapier/API hop — perfectly workable, just a step
+        more setup.
+      </p>
+
+      <h2>Method 5: Build a custom automation</h2>
+
+      <p>
+        Self-serve parsers are the right answer for most teams, and you should
+        try one before reading further. But off-the-shelf tools assume a fairly
+        clean, standard statement and a single destination. They start to crack
+        when:
+      </p>
+      <ul>
+        <li>statements come from <strong>many different banks</strong>, each with its own layout;</li>
+        <li>they're <strong>image-based scans or photos</strong> of varying quality;</li>
+        <li>volume runs to <strong>hundreds or thousands of pages a month</strong>;</li>
+        <li>the data needs <strong>reconciliation or validation</strong> (matching deposits, flagging duplicates, balancing to a control total) before it touches the books;</li>
+        <li>it has to land in <strong>QuickBooks and other systems</strong> at the same time.</li>
+      </ul>
+
+      <p>
+        That's the point where a custom automation earns its keep. Instead of a
+        person shepherding files through a converter, a purpose-built pipeline
+        reads any statement format, validates and reconciles the figures, and
+        posts them straight into QuickBooks — with a human only reviewing
+        exceptions. It costs more than a $30-a-month tool, but for a team losing
+        days a month to manual entry and clean-up, the return shows up quickly.
+        The honest trade-off: bespoke costs more up front and pays back through
+        the volume and reliability off-the-shelf tools can't reach.
+      </p>
+
+      <p>
+        This is what <strong>Bytebeam</strong> does — we build custom
+        document-processing automation for finance teams and hand the keys back
+        to you, rather than locking you into a tool you can't change.
+      </p>
+
+      <aside className="not-prose my-12" aria-label="Book a bank-statement automation scoping call">
+        <Card className="border-2 border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-background overflow-hidden">
+          <CardContent className="p-6 sm:p-8 lg:p-10">
+            <div className="flex-1 min-w-0">
+              <Badge variant="secondary" className="gap-1.5 mb-4">
+                <Sparkles className="size-3 text-primary" />
+                Bytebeam · Custom automation
+              </Badge>
+              <h3 className="text-xl sm:text-2xl font-bold leading-snug mb-3">
+                When the import methods stop scaling, automate the whole pipeline
+              </h3>
+              <p className="text-sm sm:text-base text-muted-foreground leading-relaxed mb-5">
+                Walk us through how statements flow through your books today. In
+                30 minutes we'll map the breakpoints — formats, volume,
+                reconciliation — we'd automate first, and send you a written
+                scoping summary you can take back to your team. No commitment, no
+                template demos; your process leads.
+              </p>
+              <ul className="space-y-2.5 mb-6">
+                {[
+                  "You show us how statements move through your books today",
+                  "We map the breakpoints — formats, volume, reconciliation — to automate first",
+                  "You leave with a written scoping summary, no commitment",
+                ].map((line, i) => (
+                  <li key={i} className="flex gap-2.5 text-sm text-foreground/85">
+                    <CheckCircle2 className="size-4 text-primary shrink-0 mt-0.5" />
+                    <span className="leading-relaxed">{line}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button asChild size="lg">
+                <a href={BOOKING_URL} target="_blank" rel="noopener noreferrer">
+                  <CalendarClock className="size-4 mr-2" />
+                  Book a 30-min scoping call
+                  <ArrowRight className="size-4 ml-2" />
+                </a>
+              </Button>
+              <p className="mt-4 text-xs text-muted-foreground">
+                95%+ extraction accuracy · SOC 2 / ISO 27001 / GDPR-aligned ·
+                first working pilot in ~11 days
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </aside>
+
+      <h2>Which method should you use?</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Your situation</th>
+            <th>Use this</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Your bank connects to QuickBooks</td>
+            <td>Bank feed (Method 1)</td>
+          </tr>
+          <tr>
+            <td>You have a CSV/QBO from your bank</td>
+            <td>Manual upload (Method 2 / 3)</td>
+          </tr>
+          <tr>
+            <td>You only have a clean, text-based PDF, one-off</td>
+            <td>Convert to CSV, then upload</td>
+          </tr>
+          <tr>
+            <td>Scanned PDFs or regular weekly volume</td>
+            <td>Document parser (Method 4)</td>
+          </tr>
+          <tr>
+            <td>Many banks, high volume, or reconciliation</td>
+            <td>Custom automation (Method 5)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Frequently asked questions</h2>
+
+      <h3>Can QuickBooks import a PDF bank statement?</h3>
+      <p>
+        No. QuickBooks Online accepts CSV, QBO (Web Connect), QFX, and OFX —
+        not PDF. QuickBooks Desktop uses QBO or the legacy IIF format. Convert
+        the PDF to CSV or QBO first, then upload that file.
+      </p>
+
+      <h3>What CSV format does QuickBooks Online need?</h3>
+      <p>
+        Either 3 columns (Date, Description, Amount) or 4 columns (Date,
+        Description, Credit, Debit). Keep the file under 350 KB and 1,000
+        transactions, include a header row, and strip currency symbols and
+        thousands separators so cells hold only digits, decimal points, and
+        minus signs.
+      </p>
+
+      <h3>How many transactions can I import at once?</h3>
+      <p>
+        Up to 1,000 per CSV upload in QuickBooks Online, with the file under 350
+        KB. Split a larger statement into several files and upload them one at a
+        time.
+      </p>
+
+      <h3>How do I import bank transactions into QuickBooks Desktop?</h3>
+      <p>
+        Download a Web Connect (.QBO) file from your bank and import it through
+        the Bank Feeds Center, where it's matched to your register. The legacy
+        .IIF format writes straight to the register but needs exact-match names
+        and is no longer recommended by Intuit.
+      </p>
+
+      <h3>Why does my CSV import keep failing?</h3>
+      <p>
+        Usually a date format that doesn't match what you chose during mapping, a
+        file over 350 KB, currency symbols or extra columns, or a missing header
+        row. Correct the formatting and re-upload — or use a parser that outputs a
+        QuickBooks-ready CSV automatically.
+      </p>
+
+      <h3>Is it safe to convert statements with a third-party tool?</h3>
+      <p>
+        Yes, if the tool encrypts your data and holds recognized certifications
+        (SOC 2, ISO 27001, GDPR). Review the vendor's security page before
+        uploading financial documents, and favor tools that let you delete files
+        after processing.
+      </p>
+
+      <h3>What file types can QuickBooks Online import for bank transactions?</h3>
+      <p>
+        CSV, QBO (Web Connect), QFX, and OFX. PDF is not supported — convert a
+        PDF statement to one of these formats first, then upload it.
+      </p>
+
+      <h3>How do I convert a PDF bank statement to CSV for free?</h3>
+      <p>
+        Use a free online converter or a document parser. A clean, text-based
+        PDF converts in about a minute; scanned or photographed statements need
+        a parser with OCR. Then upload the resulting CSV through{" "}
+        <strong>Transactions &rarr; Bank transactions</strong>.
+      </p>
+
+      <h3>Can I import a bank statement into QuickBooks from Excel?</h3>
+      <p>
+        Yes. Save the Excel sheet as a CSV in the required layout (Date,
+        Description, Amount, or Date, Description, Credit, Debit), keep it under
+        350 KB and 1,000 rows, then upload it like any other CSV file.
+      </p>
+
+      <BlogRelatedPosts
+        slugs={[
+          "scan-receipts-into-quickbooks",
+          "import-invoices-bills-into-quickbooks",
+          "automating-invoice-processing-2026",
+          "intelligent-document-processing-business-guide-2026",
+        ]}
+        subtitle="More on getting documents into your accounting stack — and the automation behind it."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+      <ol className="text-sm">
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/bank-transactions/format-csv-files-excel-get-bank-transactions/L4BjLWckq_US_en_US" target="_blank" rel="noopener noreferrer">
+            Format CSV files in Excel to get bank transactions into QuickBooks
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/import-transactions/manually-upload-transactions-quickbooks-online/L0rE9OXBz_US_en_US" target="_blank" rel="noopener noreferrer">
+            Manually upload transactions into QuickBooks Online
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/import-transactions/common-errors-importing-bank-transactions-using/L02IgW462_US_en_US" target="_blank" rel="noopener noreferrer">
+            Common errors when importing bank transactions
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/bank-feeds/download-bank-feed-transactions-quickbooks-desktop/L8o0Aw9VM_US_en_US" target="_blank" rel="noopener noreferrer">
+            Download Bank Feed transactions in QuickBooks Desktop
+          </a>{" "}
+          — Intuit
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: June 2026. QuickBooks features and plan limits change —
+          verify current file limits and import steps in Intuit's help center
+          when you set this up.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/import-invoices-bills-into-quickbooks.tsx
+++ b/client/src/pages/blog/import-invoices-bills-into-quickbooks.tsx
@@ -1,0 +1,603 @@
+import { Link } from "wouter";
+import { ArrowRight, CalendarClock, CheckCircle2, Sparkles } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+
+const BOOKING_URL =
+  "https://calendly.com/talal-bytebeam/bytebeam-discovery-call";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: "How to Import Invoices & Bills into QuickBooks (2026)",
+    description:
+      "Sales invoices vs vendor bills, and every way to get each into QuickBooks Online and Desktop — the Import Data tool, bill capture OCR, the US bulk-bill-import limitation, and the faster options for scanning vendor invoices at volume.",
+    image:
+      "https://bytebeam.co/images/blog/import-invoices-bills-into-quickbooks.jpg",
+    author: { "@type": "Organization", name: "ByteBeam Team" },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: "2026-06-01",
+    dateModified: "2026-06-01",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": "https://bytebeam.co/blog/import-invoices-bills-into-quickbooks",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://bytebeam.co" },
+      { "@type": "ListItem", position: 2, name: "Blog", item: "https://bytebeam.co/blog" },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Import Invoices & Bills into QuickBooks",
+        item: "https://bytebeam.co/blog/import-invoices-bills-into-quickbooks",
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is the difference between an invoice and a bill in QuickBooks?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "In QuickBooks, a sales invoice is money a customer owes you (accounts receivable), created with + New then Invoice. A bill is a vendor invoice you owe (accounts payable), entered with + New then Bill. They are separate objects with separate import paths, which is why 'import invoices into QuickBooks' can mean two different things.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I import invoices into QuickBooks Online?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "To bulk-import sales (customer) invoices, go to Settings (the gear icon) then Import data, choose Invoices, download the CSV/Excel template, fill it in, map the columns, and import. You can import up to about 100 line items per invoice and the file follows QuickBooks' template format.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I import bills into QuickBooks Online?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "It depends on your region. In QuickBooks Online US, native CSV bill import is not currently available — you enter bills manually, upload a bill PDF for QuickBooks' bill-capture OCR, or use a third-party app. In other regions, bill import is available on Essentials, Plus, and Advanced (up to about 100 bills per import, with line items and multicurrency).",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I scan a vendor invoice into QuickBooks?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Upload the invoice PDF to the Receipts/Bills area in QuickBooks Online; bill capture runs OCR and creates a Bill draft in the For review tab to confirm. It processes one document at a time and may miss line items. For volume or full line-item detail, a document parser pushes structured Bills into QuickBooks automatically.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does QuickBooks have OCR for bills?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. QuickBooks Online's bill capture reads an uploaded bill and drafts a Bill for review. It works one document at a time and focuses on header fields rather than full line-item tables, so high-volume or line-item-heavy AP usually needs a document parser or custom automation.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I import invoices into QuickBooks Desktop?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "QuickBooks Desktop uses the IIF (Intuit Interchange Format) for importing transactions like invoices and bills, but it requires exact-match names and is error-prone. Most teams use a third-party importer or a custom workflow to convert extracted data into a Desktop-ready file.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I import invoices into QuickBooks from Excel?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes, for sales invoices. Save your Excel sheet in QuickBooks' invoice import template layout, then use Settings then Import data then Invoices to map and import. For vendor bills in the US, Excel/CSV import isn't natively supported — use a parser or third-party app.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is the best tool to scan invoices into QuickBooks?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "For scanning vendor invoices into QuickBooks as bills, a document parser is the reliable route. Parsli has a native QuickBooks connector that creates bills with the PDF attached, plus line-item extraction and a free tier; Parseur and Docparser reach QuickBooks via Zapier or a formatted CSV.",
+        },
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: "How to import sales invoices into QuickBooks Online with the Import Data tool",
+    description:
+      "Bulk-import customer (sales) invoices into QuickBooks Online using the built-in Import Data tool and template.",
+    step: [
+      {
+        "@type": "HowToStep",
+        name: "Open Import data",
+        text: "In QuickBooks Online, go to Settings (the gear icon), then Import data, and choose Invoices.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Download and fill the template",
+        text: "Download the sample CSV/Excel template and enter your invoice data following its columns.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Upload and map",
+        text: "Upload your file and map each column to the matching QuickBooks invoice field.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Review and import",
+        text: "Review the preview for errors, then import. Keep to about 100 line items per invoice.",
+      },
+    ],
+  },
+];
+
+export default function ImportInvoicesBillsQuickBooksBlog() {
+  return (
+    <BlogLayout
+      title="How to Import Invoices & Bills into QuickBooks (2026)"
+      description="Sales invoices vs vendor bills, and every way to get each into QuickBooks Online and Desktop — the Import Data tool, bill capture OCR, the US bulk-bill-import limitation, and the faster options for scanning vendor invoices at volume."
+      keywords="import invoices into quickbooks online, import invoices into quickbooks, import bills into quickbooks online, scan invoices into quickbooks, invoice ocr quickbooks, import invoices into quickbooks desktop, quickbooks bill capture, scanning invoices into quickbooks"
+      canonical="https://bytebeam.co/blog/import-invoices-bills-into-quickbooks"
+      structuredData={structuredData}
+      category="Automation"
+      industry="Finance"
+      readTime="13 min"
+      date="2026-06-01"
+      author="ByteBeam Team"
+      sidebarCta={{
+        heading: "Keying vendor bills into QuickBooks by hand?",
+        buttonText: "Book a scoping call",
+        href: BOOKING_URL,
+        note: "30-min call · no commitment",
+      }}
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        "Import invoices into QuickBooks" is one search with two completely
+        different meanings — and picking the wrong path wastes an afternoon.
+        Sometimes you mean <strong>sales invoices</strong> you send customers;
+        sometimes you mean <strong>vendor invoices</strong> (bills) you receive
+        and owe. QuickBooks treats these as different objects with different
+        import routes, so the first job is knowing which one you're dealing with.
+      </p>
+
+      <p>
+        <strong>Quick answer:</strong> A <strong>sales invoice</strong> is money
+        customers owe you (AR) — bulk-import these via <strong>Settings (gear)
+        &rarr; Import data &rarr; Invoices</strong> using QuickBooks' template. A{" "}
+        <strong>bill</strong> is a vendor invoice you owe (AP) — enter it with{" "}
+        <strong>+ New &rarr; Bill</strong>, or upload the PDF so QuickBooks' bill
+        capture OCRs it into a draft. Native <strong>bulk bill import is
+        limited</strong>: in the US it isn't currently available in QuickBooks
+        Online (use manual entry, single-bill upload, or a third-party app);
+        other regions support it on Essentials, Plus, and Advanced (up to ~100
+        bills). To scan vendor invoices at volume with line items, a document
+        parser or custom automation is the reliable route.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "In QuickBooks, a sales invoice (AR, customers owe you) and a bill (AP, you owe vendors) are different objects with different import paths.",
+          "Sales invoices bulk-import via Settings → Import data → Invoices using QuickBooks' CSV/Excel template (~100 line items per invoice).",
+          "Vendor bills: enter manually (+ New → Bill) or upload a PDF for bill-capture OCR — one document at a time.",
+          "Native bulk bill import is region-limited: not available in QuickBooks Online US; available on Essentials/Plus/Advanced elsewhere.",
+          "To scan vendor invoices at volume with full line items, a document parser (Parsli) or custom automation is the dependable path.",
+        ]}
+      />
+
+      <h2>Invoices vs bills: what you're actually importing</h2>
+
+      <p>
+        The fix for the confusion is one distinction:
+      </p>
+      <ul>
+        <li>
+          <strong>Sales invoice (accounts receivable).</strong> A document{" "}
+          <em>you</em> create to charge a customer. In QuickBooks it's an{" "}
+          <strong>Invoice</strong>. Importing these usually means migrating or
+          bulk-loading invoices you've issued.
+        </li>
+        <li>
+          <strong>Bill (accounts payable).</strong> A vendor's invoice that{" "}
+          <em>you</em> receive and owe. In QuickBooks it's a <strong>Bill</strong>.
+          Importing these means getting supplier invoices into your books to pay.
+        </li>
+      </ul>
+
+      <p>
+        Most people searching to "scan" or "OCR" invoices into QuickBooks mean
+        the second one — getting vendor bills in without retyping. We cover both
+        below, starting with the native tools.
+      </p>
+
+      <h2>Method 1: Import sales invoices with the Import Data tool</h2>
+
+      <p>
+        For customer (sales) invoices, QuickBooks Online has a built-in importer:
+      </p>
+      <ol>
+        <li>Go to <strong>Settings</strong> (the gear icon) then <strong>Import data</strong>.</li>
+        <li>Choose <strong>Invoices</strong> and download the sample template.</li>
+        <li>Fill the template, upload it, and <strong>map your columns</strong> to QuickBooks fields.</li>
+        <li>Review the preview and import. Keep to about <strong>100 line items per invoice</strong>.</li>
+      </ol>
+
+      <p>
+        This is the path behind most "import invoices into QuickBooks Online"
+        searches — and it's available on standard US plans. It's built for
+        spreadsheet data you already have, not for reading a PDF a customer or
+        vendor sent you.
+      </p>
+
+      <h2>Method 2: Enter and scan vendor bills (AP)</h2>
+
+      <p>
+        Vendor bills have their own workflow. There are two native ways in:
+      </p>
+
+      <h3>Enter a bill by hand</h3>
+      <p>
+        Select <strong>+ New &rarr; Bill</strong>, choose the vendor, and key the
+        date, amount, account/category, and any line items. Fine for the
+        occasional bill; slow at volume.
+      </p>
+
+      <h3>Upload a bill for OCR (bill capture)</h3>
+      <p>
+        QuickBooks Online can read an uploaded bill for you. Upload the PDF to
+        the <strong>Receipts/Bills</strong> area (or email it in) and bill
+        capture runs OCR, drafting a <strong>Bill</strong> in the{" "}
+        <strong>For review</strong> tab. It works <strong>one document at a
+        time</strong> and focuses on header fields (vendor, date, total) more
+        than full line-item tables — so it's a real help for occasional bills,
+        less so for heavy AP.
+      </p>
+
+      <h3>Can you bulk-import bills?</h3>
+      <p>
+        This is where region matters. In <strong>QuickBooks Online US, native CSV
+        bill import isn't currently available</strong> — there's no Import-data
+        option for bills, so you're left with manual entry, one-at-a-time upload,
+        or a third-party app. In <strong>other regions</strong>, bill import is
+        available on <strong>Essentials, Plus, and Advanced</strong> (up to ~100
+        bills per import, with line items and multicurrency). Either way, there's
+        no native, high-volume "drop in a folder of vendor PDFs" path — which is
+        the gap parsers and custom automations fill.
+      </p>
+
+      <h2>Method 3: Import into QuickBooks Desktop</h2>
+
+      <p>
+        QuickBooks Desktop imports transactions like invoices and bills through
+        the legacy <strong>.IIF</strong> (Intuit Interchange Format). It works,
+        but it's strict — account names, vendors, and terms must match your file
+        exactly, or the import fails — and Intuit steers users away from it for
+        transactions. In practice, most Desktop teams use a third-party importer
+        or a custom workflow that outputs a clean, Desktop-ready file rather than
+        hand-building IIF.
+      </p>
+
+      <h2>Method 4: Scan vendor invoices with a document parser</h2>
+
+      <p>
+        A document parser reads a vendor invoice — including line items, tax, and
+        totals — and pushes structured data into QuickBooks as a bill, or exports
+        a ready-to-import file. For any team with steady AP volume, this is the
+        step up from one-at-a-time bill capture. For a quick one-off, our free{" "}
+        <Link href="/tools/invoice-parser">invoice parser</Link> extracts the
+        data in seconds.
+      </p>
+
+      <p>
+        Four self-serve parsers are worth knowing. The biggest difference is how
+        they actually land data in QuickBooks.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Best for</th>
+            <th>Path into QuickBooks</th>
+            <th>Free option</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Parsli</strong></td>
+            <td>Posting vendor invoices straight to Bills</td>
+            <td><strong>Native QuickBooks connector</strong> (Bills + PDF attached)</td>
+            <td>100 pages free, no card</td>
+          </tr>
+          <tr>
+            <td>Parseur</td>
+            <td>Forward-to-extract email workflows</td>
+            <td>CSV, or via Zapier</td>
+            <td>20 pages / month</td>
+          </tr>
+          <tr>
+            <td>Docparser</td>
+            <td>Rule-based capture at volume</td>
+            <td>Pre-formatted CSV, or via Zapier</td>
+            <td>14-day trial</td>
+          </tr>
+          <tr>
+            <td>Affinda</td>
+            <td>Enterprise volume with validation</td>
+            <td>API-first (Xero / Dynamics named)</td>
+            <td>Free converter + trial</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        <strong>
+          <a href="https://parsli.co/integrations/quickbooks" target="_blank" rel="noopener noreferrer">Parsli</a>
+        </strong>{" "}
+        is the strongest fit for AP here: its{" "}
+        <strong>native QuickBooks connector creates Bills with the original PDF
+        attached</strong>, reads full line items with built-in OCR (including
+        scanned invoices), and flags low-confidence fields for review. It's the
+        only tool of the four that posts a bill natively — the others route
+        through a formatted CSV or Zapier — and its free tier (100 pages, no card)
+        makes it easy to test on real vendor invoices.
+      </p>
+
+      <p>
+        <strong>
+          <a href="https://parseur.com" target="_blank" rel="noopener noreferrer">Parseur</a>
+        </strong>{" "}
+        uses a forward-to-extract workflow (email invoices to a dedicated address)
+        and reaches QuickBooks via Zapier. <strong>
+          <a href="https://docparser.com" target="_blank" rel="noopener noreferrer">Docparser</a>
+        </strong>{" "}
+        uses zonal OCR and parsing rules, exporting a CSV pre-formatted for
+        QuickBooks or routing through Zapier. <strong>
+          <a href="https://www.affinda.com" target="_blank" rel="noopener noreferrer">Affinda</a>
+        </strong>{" "}
+        is an enterprise document-AI platform with validation and 50+ languages,
+        integrated API-first (its named accounting connectors are Xero and
+        Microsoft Dynamics rather than QuickBooks). Of the four, only Parsli
+        creates a QuickBooks bill natively.
+      </p>
+
+      <h2>Method 5: Build a custom automation</h2>
+
+      <p>
+        Self-serve parsers handle most AP, and you should try one first. But
+        off-the-shelf tools assume a clean invoice and a simple post. They strain
+        when:
+      </p>
+      <ul>
+        <li>invoices arrive from <strong>hundreds of vendors</strong>, each with its own layout and line-item structure;</li>
+        <li>they need <strong>2-way or 3-way matching</strong> against purchase orders and goods receipts before posting;</li>
+        <li><strong>approval routing</strong> by amount or department is required;</li>
+        <li>volume runs to <strong>thousands of bills a month</strong>;</li>
+        <li>data must post to <strong>QuickBooks and an ERP or payment system</strong> at once.</li>
+      </ul>
+
+      <p>
+        That's where a custom automation pays off: a pipeline that reads any
+        invoice format, validates and matches it, routes exceptions to a human,
+        and posts clean bills into QuickBooks. It's a bigger investment than a
+        $30-a-month tool, but for an AP team drowning in manual entry and
+        clean-up, the return shows up fast. The honest trade-off: bespoke costs
+        more up front and pays back through volume, accuracy, and control. (For
+        the wider business case, see{" "}
+        <Link href="/blog/automating-invoice-processing-2026">automating invoice processing</Link>.)
+      </p>
+
+      <p>
+        This is what <strong>Bytebeam</strong> builds — custom document-processing
+        automation for finance teams, handed back to you to run.
+      </p>
+
+      <aside className="not-prose my-12" aria-label="Book an AP automation scoping call">
+        <Card className="border-2 border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-background overflow-hidden">
+          <CardContent className="p-6 sm:p-8 lg:p-10">
+            <div className="flex-1 min-w-0">
+              <Badge variant="secondary" className="gap-1.5 mb-4">
+                <Sparkles className="size-3 text-primary" />
+                Bytebeam · Custom automation
+              </Badge>
+              <h3 className="text-xl sm:text-2xl font-bold leading-snug mb-3">
+                When bill entry stops scaling, automate the whole AP pipeline
+              </h3>
+              <p className="text-sm sm:text-base text-muted-foreground leading-relaxed mb-5">
+                Walk us through how vendor invoices move through your books today
+                — the vendors, the matching, the approvals, the volume. In 30
+                minutes we'll map what we'd automate first and send you a written
+                scoping summary you can take back to your team. No commitment, no
+                template demos; your process leads.
+              </p>
+              <ul className="space-y-2.5 mb-6">
+                {[
+                  "You show us how vendor invoices reach your books today",
+                  "We map the breakpoints — matching, approvals, volume — to automate first",
+                  "You leave with a written scoping summary, no commitment",
+                ].map((line, i) => (
+                  <li key={i} className="flex gap-2.5 text-sm text-foreground/85">
+                    <CheckCircle2 className="size-4 text-primary shrink-0 mt-0.5" />
+                    <span className="leading-relaxed">{line}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button asChild size="lg">
+                <a href={BOOKING_URL} target="_blank" rel="noopener noreferrer">
+                  <CalendarClock className="size-4 mr-2" />
+                  Book a 30-min scoping call
+                  <ArrowRight className="size-4 ml-2" />
+                </a>
+              </Button>
+              <p className="mt-4 text-xs text-muted-foreground">
+                95%+ extraction accuracy · SOC 2 / ISO 27001 / GDPR-aligned ·
+                first working pilot in ~11 days
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </aside>
+
+      <h2>Which method should you use?</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Your situation</th>
+            <th>Use this</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Bulk-loading sales (customer) invoices</td>
+            <td>Import data → Invoices (Method 1)</td>
+          </tr>
+          <tr>
+            <td>An occasional vendor bill</td>
+            <td>+ New → Bill, or upload for OCR (Method 2)</td>
+          </tr>
+          <tr>
+            <td>Steady vendor-invoice volume with line items</td>
+            <td>Document parser (Method 4)</td>
+          </tr>
+          <tr>
+            <td>QuickBooks Desktop</td>
+            <td>IIF or a parser/custom workflow (Method 3 / 4)</td>
+          </tr>
+          <tr>
+            <td>High-volume AP with matching and approvals</td>
+            <td>Custom automation (Method 5)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Frequently asked questions</h2>
+
+      <h3>What is the difference between an invoice and a bill in QuickBooks?</h3>
+      <p>
+        A sales invoice is money a customer owes you (AR), created with{" "}
+        <strong>+ New &rarr; Invoice</strong>. A bill is a vendor invoice you owe
+        (AP), entered with <strong>+ New &rarr; Bill</strong>. Different objects,
+        different import paths.
+      </p>
+
+      <h3>How do I import invoices into QuickBooks Online?</h3>
+      <p>
+        For sales invoices, go to <strong>Settings &rarr; Import data &rarr;
+        Invoices</strong>, download the template, fill it in, map the columns, and
+        import (about 100 line items per invoice).
+      </p>
+
+      <h3>Can I import bills into QuickBooks Online?</h3>
+      <p>
+        In the US, native CSV bill import isn't currently available — use manual
+        entry, single-bill upload (OCR), or a third-party app. In other regions,
+        bill import is available on Essentials, Plus, and Advanced (up to ~100
+        bills per import).
+      </p>
+
+      <h3>How do I scan a vendor invoice into QuickBooks?</h3>
+      <p>
+        Upload the PDF to the Receipts/Bills area; bill capture OCRs it into a
+        Bill draft in <strong>For review</strong>. It works one document at a
+        time — for volume or full line items, use a document parser.
+      </p>
+
+      <h3>Does QuickBooks have OCR for bills?</h3>
+      <p>
+        Yes — bill capture reads an uploaded bill and drafts a Bill for review,
+        one document at a time, focused on header fields. High-volume or
+        line-item-heavy AP usually needs a parser or custom automation.
+      </p>
+
+      <h3>How do I import invoices into QuickBooks Desktop?</h3>
+      <p>
+        Desktop uses the IIF format for invoices and bills, but it needs
+        exact-match names and is error-prone. Most teams use a third-party
+        importer or a custom workflow instead.
+      </p>
+
+      <h3>Can I import invoices into QuickBooks from Excel?</h3>
+      <p>
+        Yes for sales invoices — save the sheet in QuickBooks' import template
+        layout and use <strong>Import data &rarr; Invoices</strong>. US vendor
+        bills aren't natively importable from Excel; use a parser or third-party
+        app.
+      </p>
+
+      <h3>What is the best tool to scan invoices into QuickBooks?</h3>
+      <p>
+        For vendor invoices, a document parser is the reliable route. Parsli has a
+        native QuickBooks connector that creates bills with the PDF attached, plus
+        line-item extraction and a free tier; Parseur and Docparser reach
+        QuickBooks via Zapier or a formatted CSV.
+      </p>
+
+      <BlogRelatedPosts
+        slugs={[
+          "scan-receipts-into-quickbooks",
+          "import-bank-statements-into-quickbooks",
+          "automating-invoice-processing-2026",
+          "intelligent-document-processing-business-guide-2026",
+        ]}
+        subtitle="More on getting documents into your accounting stack — and the automation behind it."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+      <ol className="text-sm">
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/invoicing/import-multiple-invoices/L7E9Xrd8l_US_en_US" target="_blank" rel="noopener noreferrer">
+            Import multiple invoices into QuickBooks Online
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/pay-bills/enter-bills-record-bill-payments-quickbooks-online/L1e9Ce5J7_US_en_US" target="_blank" rel="noopener noreferrer">
+            Enter bills and record bill payments in QuickBooks Online
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/import-transactions/upload-receipts-bills-quickbooks-online/L862MmZHn_US_en_US" target="_blank" rel="noopener noreferrer">
+            Upload receipts and bills to QuickBooks Online (bill capture)
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-global/help-article/import-transactions/import-bills-quickbooks-online/L4Q6QWsRw_ROW_en" target="_blank" rel="noopener noreferrer">
+            Import your bills in QuickBooks Online (non-US regions)
+          </a>{" "}
+          — Intuit
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: June 2026. QuickBooks features and regional availability
+          change — confirm what your plan and region support in Intuit's help
+          center when you set this up.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/scan-receipts-into-quickbooks.tsx
+++ b/client/src/pages/blog/scan-receipts-into-quickbooks.tsx
@@ -1,0 +1,614 @@
+import { Link } from "wouter";
+import { ArrowRight, CalendarClock, CheckCircle2, Sparkles } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import BlogLayout from "@/components/BlogLayout";
+import BlogKeyTakeaways from "@/components/blog/BlogKeyTakeaways";
+import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
+
+const BOOKING_URL =
+  "https://calendly.com/talal-bytebeam/bytebeam-discovery-call";
+
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: "How to Scan Receipts into QuickBooks (2026): Online, Desktop & Automated",
+    description:
+      "How to scan receipts into QuickBooks Online with Receipt Capture, the mobile app, or email — what it captures, what it misses (line items, batches), and the faster options when it falls short.",
+    image:
+      "https://bytebeam.co/images/blog/scan-receipts-into-quickbooks.jpg",
+    author: { "@type": "Organization", name: "ByteBeam Team" },
+    publisher: {
+      "@type": "Organization",
+      name: "ByteBeam",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://bytebeam.co/assets/bytebeam-logo.png",
+      },
+    },
+    datePublished: "2026-06-01",
+    dateModified: "2026-06-01",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": "https://bytebeam.co/blog/scan-receipts-into-quickbooks",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://bytebeam.co" },
+      { "@type": "ListItem", position: 2, name: "Blog", item: "https://bytebeam.co/blog" },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Scan Receipts into QuickBooks",
+        item: "https://bytebeam.co/blog/scan-receipts-into-quickbooks",
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Does QuickBooks have a receipt scanner?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. QuickBooks Online has a built-in tool called Receipt Capture — you can upload receipt images or PDFs, snap photos in the QuickBooks mobile app, or forward receipts to a dedicated email address. QuickBooks Desktop has no automatic extraction; its Scan Manager only attaches a scanned image to a transaction you enter manually.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I scan receipts into QuickBooks Online?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Go to Transactions (or Bookkeeping) then Receipts, and choose Upload from computer to add image or PDF files. You can also snap a photo in the QuickBooks mobile app or forward receipts to your QuickBooks receipts email address. Each receipt lands in the For review tab, where you confirm or match it.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I scan receipts into QuickBooks with my phone?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. In the QuickBooks mobile app, open the menu and choose Receipt snap (or Receipts), take a photo, and the app uploads it for processing. The captured receipt appears in the For review tab in QuickBooks Online.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does QuickBooks Receipt Capture extract line items?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "No. Receipt Capture reliably reads only the vendor or store name, date, total amount, and payment method. It does not break out individual line items, and it posts the receipt to an expense account. To capture line-item detail or split a receipt across categories automatically, use a document parser.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I email receipts to QuickBooks?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. QuickBooks Online gives each company a dedicated receipts email address (find it in the Receipts tab). Forward an emailed receipt or e-receipt to that address and QuickBooks imports it automatically into the For review tab.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is the best receipt scanner for QuickBooks?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "For basic expense capture, QuickBooks Online's built-in Receipt Capture is enough. If you need line-item detail, bulk scanning, or receipts coded to non-expense accounts, a document parser such as Parsli (which has a native QuickBooks connector and a free tier), Parseur, or Docparser is a better fit.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I scan receipts into QuickBooks Desktop?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "QuickBooks Desktop has no built-in receipt OCR. Its Scan Manager attaches a scanned image to a transaction, but you still key the data by hand. To automate Desktop, use a document parser or a custom workflow that outputs the data in a format Desktop can import.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How many receipts can I scan into QuickBooks at once?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Receipt Capture processes receipts individually — you can upload several files, but each is read and reviewed one at a time, with no true batch workflow. For high volume, a document parser or custom automation processes receipts in bulk and pushes the results into QuickBooks.",
+        },
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: "How to scan receipts into QuickBooks Online",
+    description:
+      "Capture receipts in QuickBooks Online using upload, the mobile app, or email forwarding.",
+    step: [
+      {
+        "@type": "HowToStep",
+        name: "Open the Receipts tab",
+        text: "In QuickBooks Online, go to Transactions (or Bookkeeping), then Receipts.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Add your receipts",
+        text: "Choose Upload from computer for image or PDF files, snap a photo in the QuickBooks mobile app, or forward receipts to your QuickBooks receipts email address.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Let QuickBooks read them",
+        text: "QuickBooks runs OCR and extracts the vendor, date, total, and payment method, placing each receipt in the For review tab.",
+      },
+      {
+        "@type": "HowToStep",
+        name: "Review and confirm",
+        text: "Open each receipt, confirm or correct the details, choose the account and category, and match it to an existing transaction or add it as new.",
+      },
+    ],
+  },
+];
+
+export default function ScanReceiptsQuickBooksBlog() {
+  return (
+    <BlogLayout
+      title="How to Scan Receipts into QuickBooks (2026): Online, Desktop & Automated"
+      description="How to scan receipts into QuickBooks Online with Receipt Capture, the mobile app, or email — what it captures, what it misses (line items, batches), and the faster options when it falls short."
+      keywords="scan receipts into quickbooks, quickbooks receipt scanner, scan receipts in quickbooks online, capture receipts in quickbooks, upload receipts to quickbooks, best receipt scanner for quickbooks, quickbooks receipt scanner app, scan receipts quickbooks desktop"
+      canonical="https://bytebeam.co/blog/scan-receipts-into-quickbooks"
+      structuredData={structuredData}
+      category="Automation"
+      industry="Finance"
+      readTime="12 min"
+      date="2026-06-01"
+      author="ByteBeam Team"
+      sidebarCta={{
+        heading: "Receipts piling up faster than you can code them?",
+        buttonText: "Book a scoping call",
+        href: BOOKING_URL,
+        note: "30-min call · no commitment",
+      }}
+    >
+      <p className="text-xl leading-relaxed mb-8">
+        The shoebox of receipts is the most universal bookkeeping chore there
+        is. The good news: QuickBooks Online has a <strong>built-in receipt
+        scanner</strong>, and you don't need a third-party app to start. The
+        catch: it captures the basics — vendor, date, total — but stops short of
+        line items, batches, and anything that isn't a simple expense.
+      </p>
+
+      <p>
+        <strong>Quick answer:</strong> QuickBooks Online has a built-in receipt
+        scanner. <strong>Upload</strong> images or PDFs, <strong>snap</strong>{" "}
+        photos in the QuickBooks mobile app, or <strong>forward</strong> receipts
+        to your QuickBooks receipts email address — it runs OCR and drops each
+        one in the <strong>For review</strong> tab to confirm. It captures
+        vendor, date, total, and payment method, but <strong>not line
+        items</strong>, and posts to an expense account only. QuickBooks Desktop
+        has no built-in extraction (Scan Manager just attaches the image). For
+        line-item detail, bulk scanning, or non-expense coding, use a document
+        parser or a custom automation.
+      </p>
+
+      <p>
+        Below is every way to scan receipts into QuickBooks — online, on mobile,
+        and automated — with the exact steps, the real limits of the native
+        tool, and when it's worth reaching for something more capable.
+      </p>
+
+      <BlogKeyTakeaways
+        points={[
+          "QuickBooks Online has three native ways to capture receipts: upload, the mobile app's Receipt snap, and a forward-to email address.",
+          "Receipt Capture reads vendor, date, total, and payment method — but not line items — and posts to an expense account only.",
+          "QuickBooks Desktop has no auto-extraction; Scan Manager only attaches the scanned image to a transaction you key manually.",
+          "There is no true batch mode — receipts are reviewed one at a time, which becomes the bottleneck at volume.",
+          "For line items, bulk capture, or coding to non-expense accounts, a document parser or custom automation is the better tool.",
+        ]}
+      />
+
+      <h2>The methods at a glance</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Best for</th>
+            <th>What you get</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Receipt Capture — upload</td>
+            <td>A handful of digital receipts</td>
+            <td>OCR'd vendor / date / total in For review</td>
+          </tr>
+          <tr>
+            <td>Receipt Capture — mobile snap</td>
+            <td>Receipts on the go</td>
+            <td>Photo to transaction from your phone</td>
+          </tr>
+          <tr>
+            <td>Receipt Capture — email forward</td>
+            <td>Emailed and e-receipts</td>
+            <td>Auto-import by forwarding</td>
+          </tr>
+          <tr>
+            <td>Document parser (SaaS)</td>
+            <td>Line items, volume, mixed formats</td>
+            <td>Structured data incl. line items into QuickBooks</td>
+          </tr>
+          <tr>
+            <td>Custom automation</td>
+            <td>High volume, coding rules, approvals</td>
+            <td>Hands-off receipts into QuickBooks</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Method 1: Scan receipts in QuickBooks Online (Receipt Capture)</h2>
+
+      <p>
+        QuickBooks Online's receipt tool is called <strong>Receipt
+        Capture</strong>. It accepts PDF, JPEG, JPG, GIF, and PNG files, runs OCR
+        to read the key fields, and creates a transaction you confirm. There are
+        three ways to feed it.
+      </p>
+
+      <h3>Upload from your computer</h3>
+      <ol>
+        <li>Go to <strong>Transactions</strong> (or <strong>Bookkeeping</strong>) then <strong>Receipts</strong>.</li>
+        <li>Select <strong>Upload from computer</strong> and choose your image or PDF files.</li>
+        <li>QuickBooks reads each receipt and places it in the <strong>For review</strong> tab.</li>
+      </ol>
+
+      <h3>Snap a photo with the mobile app</h3>
+      <ol>
+        <li>Open the <strong>QuickBooks mobile app</strong>.</li>
+        <li>Tap the menu and choose <strong>Receipt snap</strong> (or <strong>Receipts</strong>).</li>
+        <li>Photograph the receipt; the app uploads it and it appears in <strong>For review</strong> in QuickBooks Online.</li>
+      </ol>
+
+      <h3>Forward receipts by email</h3>
+      <ol>
+        <li>In the <strong>Receipts</strong> tab, find your company's dedicated <strong>receipts email address</strong>.</li>
+        <li>Forward any emailed receipt or e-receipt to it.</li>
+        <li>QuickBooks imports it automatically — handy for online purchases that never become paper.</li>
+      </ol>
+
+      <p>
+        However you add them, receipts queue in the <strong>For review</strong>{" "}
+        tab. You open each one, confirm the vendor, date, and amount QuickBooks
+        read, set the account and category, and either <strong>match</strong> it
+        to an existing transaction (like a bank-feed entry) or <strong>add</strong>{" "}
+        it as new.
+      </p>
+
+      <h2>The limits of Receipt Capture</h2>
+
+      <p>
+        Receipt Capture is genuinely useful for everyday expenses, but it was
+        built for the simple case. Where it struggles:
+      </p>
+      <ul>
+        <li><strong>No line items.</strong> It reads the vendor, date, total, and payment method — not the individual items on the receipt. If you need to split a big-box receipt across several categories, you do it by hand.</li>
+        <li><strong>Expense account only.</strong> Capture posts to an expense account. Receipts that should hit an asset, inventory, or other account need manual reclassifying.</li>
+        <li><strong>No true batch.</strong> You can upload several files, but each is read and reviewed individually. A stack of 200 receipts is still 200 reviews.</li>
+        <li><strong>Accuracy varies.</strong> Crumpled, faded, foreign-currency, or non-standard receipts are read less reliably and need correcting.</li>
+        <li><strong>The vendor-invoice trap.</strong> A vendor invoice dropped into Receipt Capture gets booked as an expense, bypassing the Accounts Payable workflow entirely. (For those, see{" "}
+          <Link href="/blog/import-invoices-bills-into-quickbooks">importing invoices and bills into QuickBooks</Link>.)
+        </li>
+      </ul>
+
+      <h2>Method 2: Receipts in QuickBooks Desktop</h2>
+
+      <p>
+        QuickBooks Desktop has no equivalent to Receipt Capture. Its{" "}
+        <strong>Scan Manager</strong> lets you scan a paper receipt and{" "}
+        <em>attach the image</em> to a transaction — an expense or a bill — but
+        it does <strong>not</strong> read any data off it. You still type the
+        vendor, amount, and account in by hand. To automate receipts on Desktop,
+        you need a document parser or a custom workflow that produces an
+        importable file.
+      </p>
+
+      <h2>Method 3: Scan receipts with a document parser</h2>
+
+      <p>
+        A document parser reads a receipt — including the line items — and
+        outputs structured data you can push into QuickBooks or drop into a
+        spreadsheet. For teams that handle real volume, code receipts to
+        multiple accounts, or want every line captured, this is the step up from
+        Receipt Capture. For a quick one-off, our own free{" "}
+        <Link href="/tools/receipt-scanner">receipt scanner</Link> extracts the
+        data in seconds.
+      </p>
+
+      <p>
+        Four self-serve parsers are worth knowing. They differ most in how they
+        push data into QuickBooks and what they cost to start.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Best for</th>
+            <th>Path into QuickBooks</th>
+            <th>Free option</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Parsli</strong></td>
+            <td>Simplest path into QuickBooks; line items</td>
+            <td><strong>Native QuickBooks connector</strong> + CSV</td>
+            <td>100 pages free, no card</td>
+          </tr>
+          <tr>
+            <td>Parseur</td>
+            <td>Forward-to-extract email workflows</td>
+            <td>CSV, or via Zapier</td>
+            <td>20 pages / month</td>
+          </tr>
+          <tr>
+            <td>Docparser</td>
+            <td>Rule-based capture at volume</td>
+            <td>Pre-formatted CSV, or via Zapier</td>
+            <td>14-day trial</td>
+          </tr>
+          <tr>
+            <td>Affinda</td>
+            <td>Enterprise volume with validation</td>
+            <td>API-first</td>
+            <td>Free converter + trial</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        <strong>
+          <a href="https://parsli.co/integrations/quickbooks" target="_blank" rel="noopener noreferrer">Parsli</a>
+        </strong>{" "}
+        reads printed, scanned, and even handwritten receipts with built-in OCR,
+        captures the full line-item detail (not just the total), and applies
+        confidence scores so you only review what's uncertain. It's the one tool
+        here with a <strong>native QuickBooks connector</strong>, so data posts
+        straight into QuickBooks rather than through a third-party hop, and its
+        free tier (100 pages, no card) makes it easy to test on your own
+        receipts.
+      </p>
+
+      <p>
+        <strong>
+          <a href="https://parseur.com" target="_blank" rel="noopener noreferrer">Parseur</a>
+        </strong>{" "}
+        is built around a forward-to-extract workflow — email receipts to a
+        dedicated address and it returns structured data with no rules to build,
+        reaching QuickBooks through Zapier. <strong>
+          <a href="https://docparser.com" target="_blank" rel="noopener noreferrer">Docparser</a>
+        </strong>{" "}
+        uses zonal OCR and parsing rules to pull fields from consistent receipt
+        layouts and can export a CSV pre-formatted for QuickBooks. <strong>
+          <a href="https://www.affinda.com" target="_blank" rel="noopener noreferrer">Affinda</a>
+        </strong>{" "}
+        is an enterprise document-AI platform with validation and 50+ language
+        support, integrated API-first for higher-volume or compliance-sensitive
+        teams. Of the four, only Parsli ships a native QuickBooks connector — the
+        others reach QuickBooks via a formatted CSV or a Zapier/API hop.
+      </p>
+
+      <h2>Method 4: Build a custom automation</h2>
+
+      <p>
+        Self-serve parsers cover most teams, and you should try one before going
+        further. But off-the-shelf tools assume a tidy receipt and a single
+        destination. They start to strain when:
+      </p>
+      <ul>
+        <li>receipts arrive from <strong>many sources</strong> — email, drivers' photos, expense apps, paper — in wildly different shapes;</li>
+        <li>you need <strong>line items split and coded</strong> to projects, classes, or locations, not just lumped into one expense;</li>
+        <li>volume runs to <strong>thousands a month</strong> with approval routing;</li>
+        <li>receipts must reconcile against <strong>card feeds or expense reports</strong> before they post;</li>
+        <li>data has to land in <strong>QuickBooks and other systems</strong> at once.</li>
+      </ul>
+
+      <p>
+        That's where a custom automation pays off: a pipeline that reads any
+        receipt format, codes and splits it by your rules, reconciles it, and
+        posts it into QuickBooks — with a person only handling exceptions. It
+        costs more than an off-the-shelf app, but for a team losing days a month
+        to receipt entry, it returns more. The honest trade-off: bespoke is a
+        bigger investment up front and pays back through volume and accuracy.
+      </p>
+
+      <p>
+        This is what <strong>Bytebeam</strong> does — we build custom
+        document-processing automation for finance teams and hand the keys back
+        to you.
+      </p>
+
+      <aside className="not-prose my-12" aria-label="Book a receipt automation scoping call">
+        <Card className="border-2 border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-background overflow-hidden">
+          <CardContent className="p-6 sm:p-8 lg:p-10">
+            <div className="flex-1 min-w-0">
+              <Badge variant="secondary" className="gap-1.5 mb-4">
+                <Sparkles className="size-3 text-primary" />
+                Bytebeam · Custom automation
+              </Badge>
+              <h3 className="text-xl sm:text-2xl font-bold leading-snug mb-3">
+                When Receipt Capture stops keeping up, automate the whole flow
+              </h3>
+              <p className="text-sm sm:text-base text-muted-foreground leading-relaxed mb-5">
+                Walk us through how receipts reach your books today — the
+                sources, the coding rules, the volume. In 30 minutes we'll map
+                what we'd automate first and send you a written scoping summary
+                you can take back to your team. No commitment, no template demos;
+                your process leads.
+              </p>
+              <ul className="space-y-2.5 mb-6">
+                {[
+                  "You show us how receipts reach your books today",
+                  "We map the breakpoints — sources, coding, volume — to automate first",
+                  "You leave with a written scoping summary, no commitment",
+                ].map((line, i) => (
+                  <li key={i} className="flex gap-2.5 text-sm text-foreground/85">
+                    <CheckCircle2 className="size-4 text-primary shrink-0 mt-0.5" />
+                    <span className="leading-relaxed">{line}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button asChild size="lg">
+                <a href={BOOKING_URL} target="_blank" rel="noopener noreferrer">
+                  <CalendarClock className="size-4 mr-2" />
+                  Book a 30-min scoping call
+                  <ArrowRight className="size-4 ml-2" />
+                </a>
+              </Button>
+              <p className="mt-4 text-xs text-muted-foreground">
+                95%+ extraction accuracy · SOC 2 / ISO 27001 / GDPR-aligned ·
+                first working pilot in ~11 days
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </aside>
+
+      <h2>Which method should you use?</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Your situation</th>
+            <th>Use this</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>A few expense receipts, QuickBooks Online</td>
+            <td>Receipt Capture — upload or mobile (Method 1)</td>
+          </tr>
+          <tr>
+            <td>Online / emailed receipts</td>
+            <td>Receipt Capture — email forward</td>
+          </tr>
+          <tr>
+            <td>You need line items or non-expense coding</td>
+            <td>Document parser (Method 3)</td>
+          </tr>
+          <tr>
+            <td>QuickBooks Desktop</td>
+            <td>Parser or custom workflow (Method 3 / 4)</td>
+          </tr>
+          <tr>
+            <td>High volume, coding rules, approvals</td>
+            <td>Custom automation (Method 4)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Frequently asked questions</h2>
+
+      <h3>Does QuickBooks have a receipt scanner?</h3>
+      <p>
+        Yes — QuickBooks Online has Receipt Capture (upload, mobile snap, or
+        email forwarding). QuickBooks Desktop has no automatic extraction; its
+        Scan Manager only attaches a scanned image to a transaction you enter
+        manually.
+      </p>
+
+      <h3>How do I scan receipts into QuickBooks Online?</h3>
+      <p>
+        Go to <strong>Transactions &rarr; Receipts</strong> and choose{" "}
+        <strong>Upload from computer</strong>, snap a photo in the QuickBooks
+        mobile app, or forward receipts to your QuickBooks receipts email
+        address. Each one lands in the <strong>For review</strong> tab to
+        confirm.
+      </p>
+
+      <h3>Can I scan receipts into QuickBooks with my phone?</h3>
+      <p>
+        Yes. In the QuickBooks mobile app, open the menu, choose{" "}
+        <strong>Receipt snap</strong>, and take a photo — it uploads and appears
+        in the For review tab in QuickBooks Online.
+      </p>
+
+      <h3>Does QuickBooks Receipt Capture read line items?</h3>
+      <p>
+        No. It captures the vendor, date, total, and payment method only, and
+        posts to an expense account. For line-item detail or splitting a receipt
+        across categories, use a document parser.
+      </p>
+
+      <h3>Can I email receipts to QuickBooks?</h3>
+      <p>
+        Yes. Each QuickBooks Online company has a dedicated receipts email
+        address (in the Receipts tab). Forward a receipt to it and QuickBooks
+        imports it automatically.
+      </p>
+
+      <h3>What is the best receipt scanner for QuickBooks?</h3>
+      <p>
+        For basic expenses, the built-in Receipt Capture is enough. For line
+        items, bulk scanning, or non-expense coding, a document parser such as
+        Parsli (native QuickBooks connector, free tier), Parseur, or Docparser is
+        a better fit.
+      </p>
+
+      <h3>Can I scan receipts into QuickBooks Desktop?</h3>
+      <p>
+        Not with automatic data capture. Scan Manager attaches the image, but you
+        key the data manually — or use a parser/custom workflow to produce an
+        importable file.
+      </p>
+
+      <h3>How many receipts can I scan at once?</h3>
+      <p>
+        Receipt Capture handles receipts individually with no true batch mode.
+        For bulk processing, a document parser or custom automation reads many
+        receipts at once and pushes the results into QuickBooks.
+      </p>
+
+      <BlogRelatedPosts
+        slugs={[
+          "import-bank-statements-into-quickbooks",
+          "import-invoices-bills-into-quickbooks",
+          "automating-invoice-processing-2026",
+          "intelligent-document-processing-business-guide-2026",
+        ]}
+        subtitle="More on getting documents into your accounting stack — and the automation behind it."
+      />
+
+      <hr />
+
+      <h2>References</h2>
+      <ol className="text-sm">
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/import-transactions/upload-receipts-bills-quickbooks-online/L862MmZHn_US_en_US" target="_blank" rel="noopener noreferrer">
+            Upload receipts and bills to QuickBooks Online
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/r/expenses/receipt-capture-app/" target="_blank" rel="noopener noreferrer">
+            Receipt Capture: snap and store receipts
+          </a>{" "}
+          — Intuit
+        </li>
+        <li>
+          <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/install-products/quickbooks-scan-manager-scan-attach-documents/L9Z3Fi2L9_US_en_US" target="_blank" rel="noopener noreferrer">
+            QuickBooks Scan Manager: scan and attach documents (Desktop)
+          </a>{" "}
+          — Intuit
+        </li>
+      </ol>
+
+      <p className="text-sm text-muted-foreground mt-8">
+        <em>
+          Last updated: June 2026. QuickBooks features and navigation change —
+          confirm current steps in Intuit's help center when you set this up.
+        </em>
+      </p>
+    </BlogLayout>
+  );
+}

--- a/client/src/pages/blog/uae-food-labeling-requirements-2026.tsx
+++ b/client/src/pages/blog/uae-food-labeling-requirements-2026.tsx
@@ -1,4 +1,5 @@
 import { Link } from "wouter";
+import { Check } from "lucide-react";
 import BlogLayout from "@/components/BlogLayout";
 
 const structuredData = [
@@ -102,14 +103,21 @@ export default function UAEFoodLabelingBlog() {
       author="ByteBeam Team"
     >
       {/* Key Takeaways Box */}
-      <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-xl p-6 my-8">
-        <h2 className="text-lg font-bold text-blue-900 dark:text-blue-200 mt-0 mb-3">Key Takeaways</h2>
-        <ul className="space-y-2 mb-0">
-          <li className="text-blue-800 dark:text-blue-300"><strong>12 mandatory label elements</strong> are required on all food products sold in the UAE, in both Arabic and English.</li>
-          <li className="text-blue-800 dark:text-blue-300"><strong>Arabic text must match or exceed</strong> the size of English text, with a minimum character height of 1.6mm.</li>
-          <li className="text-blue-800 dark:text-blue-300"><strong>Nutritional declarations</strong> must follow GSO 2233:2021 standards, listing energy, protein, fat, carbohydrates, sugars, and sodium per 100g/100ml.</li>
-          <li className="text-blue-800 dark:text-blue-300"><strong>Product registration</strong> through Dubai Municipality's Montaji Portal or ADAFSA's FIEMIS system is mandatory before import.</li>
-          <li className="text-blue-800 dark:text-blue-300"><strong>Penalties start at AED 10,000</strong> for technical violations and reach AED 2,000,000+ for serious offenses.</li>
+      <div className="not-prose rounded-xl border border-primary/20 bg-primary/5 p-6 my-8">
+        <h2 className="text-sm font-bold uppercase tracking-wider text-primary mt-0 mb-4">Key Takeaways</h2>
+        <ul className="space-y-3 m-0 list-none pl-0">
+          {[
+            <><strong className="font-semibold text-foreground">12 mandatory label elements</strong> are required on all food products sold in the UAE, in both Arabic and English.</>,
+            <><strong className="font-semibold text-foreground">Arabic text must match or exceed</strong> the size of English text, with a minimum character height of 1.6mm.</>,
+            <><strong className="font-semibold text-foreground">Nutritional declarations</strong> must follow GSO 2233:2021 standards, listing energy, protein, fat, carbohydrates, sugars, and sodium per 100g/100ml.</>,
+            <><strong className="font-semibold text-foreground">Product registration</strong> through Dubai Municipality's Montaji Portal or ADAFSA's FIEMIS system is mandatory before import.</>,
+            <><strong className="font-semibold text-foreground">Penalties start at AED 10,000</strong> for technical violations and reach AED 2,000,000+ for serious offenses.</>,
+          ].map((item, i) => (
+            <li key={i} className="flex gap-3 m-0 text-foreground/90 leading-relaxed">
+              <Check className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+              <span>{item}</span>
+            </li>
+          ))}
         </ul>
       </div>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,6 +94,9 @@ export const routesToPrerender = [
   
   // Blog
   "/blog",
+  "/blog/import-bank-statements-into-quickbooks",
+  "/blog/scan-receipts-into-quickbooks",
+  "/blog/import-invoices-bills-into-quickbooks",
   "/blog/automation-platform-comparison-2026",
   "/blog/uae-food-labeling-requirements-2026",
   "/blog/sfda-drug-registration-guide-saudi-arabia",


### PR DESCRIPTION
## Summary
Adds three GEO-optimized how-to guides for the Bytebeam blog, each owning a distinct QuickBooks data-entry intent (no keyword cannibalization), plus the blog table-of-contents sidebar the pages render through.

- **Scan receipts into QuickBooks** — `/blog/scan-receipts-into-quickbooks`
- **Import bank statements into QuickBooks** — `/blog/import-bank-statements-into-quickbooks`
- **Import invoices & bills into QuickBooks** — `/blog/import-invoices-bills-into-quickbooks`

Each guide: native QuickBooks methods → self-serve SaaS parser comparison → custom-automation offer, with a liftable "quick answer," conversational FAQ, and `Article` + `BreadcrumbList` + `FAQPage` + `HowTo` JSON-LD for AI/search citation.

Also includes the `BlogToc` sidebar + key-takeaways styling refresh the new pages depend on, and registration in `posts.ts`, `App.tsx` routes, the prerender list, `sitemap.xml`, and `feed.xml`.

## Test plan
- [x] All three pages render in dev (nav, TOC, tables, CTAs)
- [x] JSON-LD valid (Article/Breadcrumb/FAQPage/HowTo parse)
- [x] Internal + competitor + Parsli links resolve; 0 nested anchors in content
- [x] `tsc` clean for the new files (pre-existing repo errors unrelated)
- [x] Appear in the blog index Automation section; cluster cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)