### PR TITLE
redirect: 301 /tools/policy-analyzer → parsli.co/document-types/insurance-policies

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -58,6 +58,11 @@
       "source": "/tools/screenshot-to-text",
       "destination": "https://parsli.co/tools/screenshot-to-text",
       "statusCode": 301
+    },
+    {
+      "source": "/tools/policy-analyzer",
+      "destination": "https://parsli.co/document-types/insurance-policies",
+      "statusCode": 301
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary

Adds a permanent 301 redirect from `bytebeam.co/tools/policy-analyzer` to `https://parsli.co/document-types/insurance-policies`.

This transfers the ranking equity of bytebeam's #1–2 insurance policy analyzer page (~2,575 impressions, 59 clicks, avg pos 9.49 over 3 months) to the new Parsli document-type page, which launched today (parsli PR #278).

Same pattern as the existing `/tools/bank-statement-parser`, `/tools/resume-parser`, and `/tools/screenshot-to-text` redirects already in `vercel.json`.

## Verification after deploy

```
curl -sI https://www.bytebeam.co/tools/policy-analyzer
```
Expected: `301` + `location: https://parsli.co/document-types/insurance-policies`

Then request re-indexing in GSC (bytebeam.co property) for the redirected URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)