### PR TITLE
redirect: 301 /industries/insurance → parsli.co/document-types/insurance-policies

### DIFF
--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -115,6 +115,9 @@ const ROUTES = [
   '/blog/no-code-document-automation-regulatory-teams-2026',
   '/blog/intelligent-document-processing-business-guide-2026',
   '/blog/automating-invoice-processing-2026',
+  '/blog/import-bank-statements-into-quickbooks',
+  '/blog/scan-receipts-into-quickbooks',
+  '/blog/import-invoices-bills-into-quickbooks',
 
   // SFDA Regulatory Tools
   '/sfda',

--- a/vercel.json
+++ b/vercel.json
@@ -63,6 +63,11 @@
       "source": "/tools/policy-analyzer",
       "destination": "https://parsli.co/document-types/insurance-policies",
       "statusCode": 301
+    },
+    {
+      "source": "/industries/insurance",
+      "destination": "https://parsli.co/document-types/insurance-policies",
+      "statusCode": 301
     }
   ],
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -58,6 +58,11 @@
       "source": "/tools/screenshot-to-text",
       "destination": "https://parsli.co/tools/screenshot-to-text",
       "statusCode": 301
+    },
+    {
+      "source": "/tools/policy-analyzer",
+      "destination": "https://parsli.co/document-types/insurance-policies",
+      "statusCode": 301
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Routes `bytebeam.co/industries/insurance` to Parsli's insurance-policies document-type page via 301, consistent with the existing `/tools/policy-analyzer` redirect to the same destination.

Also includes previously uncommitted prerender routes for the QuickBooks blog cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)